### PR TITLE
Feature/validation callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Legion Low Level Rendering Interface, a middle layer between the graphics APIs a
 ## Dependencies
 (All libraries can already be found in the [deps](https://github.com/Legion-Engine/Legion-LLRI/tree/main/deps) folder)
 * [Legion shader preprocessor (lgnspre)](https://github.com/Legion-Engine/LegionShaderPreprocess)
+* [Vulkan SDK (for VK builds)](https://www.lunarg.com/vulkan-sdk/)
 
 ## Contributing
 

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -1,7 +1,7 @@
 #include "testsystem.hpp"
 
-//#define LLRI_ENABLE_VALIDATION 0 //uncommenting this disables internal validation (see docs)
-//#define LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING 0 //uncommenting this disables internal API message polling
+//#define LLRI_DISABLE_VALIDATION //uncommenting this disables internal validation (see docs)
+//#define LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING //uncommenting this disables internal API message polling
 #include <llri/llri.hpp>
 
 namespace llri = legion::graphics::llri;

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -12,13 +12,12 @@ void callback(const llri::validation_callback_severity& severity, const llri::va
     switch (severity)
     {
         case llri::validation_callback_severity::Verbose:
-            return; //Comment out return and uncomment the following 2 lines to get verbose callbacks
-            //sev = lgn::log::severity_trace;
-            //break;
+            sev = lgn::log::severity_trace;
+            break;
         case llri::validation_callback_severity::Info:
-            return; //Comment out return and uncomment the following 2 lines to get info callbacks
-            //sev = lgn::log::severity_info;
-            //break;
+            //Even though this semantically maps to info, we'd recommend running this on the trace severity to avoid the excessive info logs that some APIs output
+            sev = lgn::log::severity_trace;
+            break;
         case llri::validation_callback_severity::Warning:
             sev = lgn::log::severity_warn;
             break;

--- a/legion/engine/llri-dx/instance_extensions.cpp
+++ b/legion/engine/llri-dx/instance_extensions.cpp
@@ -3,23 +3,26 @@
 
 namespace legion::graphics::llri
 {
-    bool queryInstanceExtensionSupport(const instance_extension_type& type)
+    namespace detail
     {
-        switch (type)
+        bool queryInstanceExtensionSupport(const instance_extension_type& type)
         {
-            case instance_extension_type::APIValidation:
+            switch (type)
             {
-                ID3D12Debug* temp = nullptr;
-                return SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
+                case instance_extension_type::APIValidation:
+                {
+                    ID3D12Debug* temp = nullptr;
+                    return SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
+                }
+                case instance_extension_type::GPUValidation:
+                {
+                    ID3D12Debug1* temp = nullptr;
+                    return SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
+                }
             }
-            case instance_extension_type::GPUValidation:
-            {
-                ID3D12Debug1* temp = nullptr;
-                return SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
-            }
-        }
 
-        return false;
+            return false;
+        }
     }
 
     namespace internal

--- a/legion/engine/llri-dx/source.cpp
+++ b/legion/engine/llri-dx/source.cpp
@@ -133,7 +133,7 @@ namespace legion::graphics::llri
                     SIZE_T messageLength = 0;
                     iq->GetMessage(i, NULL, &messageLength);
                     
-                    D3D12_MESSAGE* pMessage = (D3D12_MESSAGE*)malloc(messageLength);
+                    D3D12_MESSAGE* pMessage = reinterpret_cast<D3D12_MESSAGE*>(malloc(messageLength));
                     iq->GetMessage(i, pMessage, &messageLength);
                     validation(internal::mapSeverity(pMessage->Severity), validation_callback_source::InternalAPI, pMessage->pDescription);
                     

--- a/legion/engine/llri-dx/source.cpp
+++ b/legion/engine/llri-dx/source.cpp
@@ -1,6 +1,7 @@
 #include <llri/llri.hpp>
 #include <graphics/directx/d3d12.h>
 #include <dxgi1_6.h>
+#include <string>
 
 namespace legion::graphics::llri
 {
@@ -9,88 +10,143 @@ namespace legion::graphics::llri
         result createAPIValidationEXT(const api_validation_ext& ext, void** output);
         result createGPUValidationEXT(const gpu_validation_ext& ext, void** output);
         result mapHRESULT(const HRESULT& value);
+
+        void dummyValidationCallback(const validation_callback_severity&, const validation_callback_source&, const char*, void*) { }
+
+        validation_callback_severity mapSeverity(D3D12_MESSAGE_SEVERITY sev)
+        {
+            switch (sev)
+            {
+            case D3D12_MESSAGE_SEVERITY_CORRUPTION:
+                return validation_callback_severity::Corruption;
+            case D3D12_MESSAGE_SEVERITY_ERROR:
+                return validation_callback_severity::Error;
+            case D3D12_MESSAGE_SEVERITY_WARNING:
+                return validation_callback_severity::Warning;
+            case D3D12_MESSAGE_SEVERITY_INFO:
+                return validation_callback_severity::Info;
+            case D3D12_MESSAGE_SEVERITY_MESSAGE:
+                return validation_callback_severity::Verbose;
+            }
+
+            return validation_callback_severity::Info;
+        }
     }
 
-    result createInstance(const instance_desc& desc, Instance** instance)
+    namespace detail
     {
-        if (instance == nullptr)
-            return result::ErrorInvalidUsage;
-        if (desc.numExtensions > 0 && desc.extensions == nullptr)
-            return result::ErrorInvalidUsage;
-
-        auto* output = new Instance();
-        UINT factoryFlags = 0;
-
-        for (uint32_t i = 0; i < desc.numExtensions; i++)
+        result createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling)
         {
-            auto& extension = desc.extensions[i];
-            result extensionCreateResult;
+            auto* output = new Instance();
+            UINT factoryFlags = 0;
 
-            switch (extension.type)
+            for (uint32_t i = 0; i < desc.numExtensions; i++)
             {
-                case instance_extension_type::APIValidation:
+                auto& extension = desc.extensions[i];
+                result extensionCreateResult;
+
+                switch (extension.type)
                 {
-                    extensionCreateResult = internal::createAPIValidationEXT(extension.apiValidation, &output->m_debugAPI);
-                    if (extensionCreateResult == result::Success)
-                        factoryFlags = DXGI_CREATE_FACTORY_DEBUG;
-                    break;
+                    case instance_extension_type::APIValidation:
+                    {
+                        extensionCreateResult = internal::createAPIValidationEXT(extension.apiValidation, &output->m_debugAPI);
+                        if (extensionCreateResult == result::Success)
+                            factoryFlags = DXGI_CREATE_FACTORY_DEBUG;
+                        break;
+                    }
+                    case instance_extension_type::GPUValidation:
+                    {
+                        extensionCreateResult = internal::createGPUValidationEXT(extension.gpuValidation, &output->m_debugGPU);
+                        break;
+                    }
+                    default:
+                    {
+                        if (desc.callbackDesc.callback)
+                            desc.callbackDesc(validation_callback_severity::Error, validation_callback_source::Validation, (std::string("createInstance() returned ErrorExtensionNotSupported because the extension type ") + std::to_string((int)extension.type) + " is not recognized.").c_str());
+
+                        extensionCreateResult = result::ErrorExtensionNotSupported;
+                        break;
+                    }
                 }
-                case instance_extension_type::GPUValidation:
+
+                if (extensionCreateResult != result::Success)
                 {
-                    extensionCreateResult = internal::createGPUValidationEXT(extension.gpuValidation, &output->m_debugGPU);
-                    break;
-                }
-                default:
-                {
-                    extensionCreateResult = result::ErrorExtensionNotSupported;
-                    break;
+                    llri::destroyInstance(output);
+                    return extensionCreateResult;
                 }
             }
 
-            if (extensionCreateResult != result::Success)
+            //Store user defined validation callback
+            //DirectX creates validation callbacks upon device creation so we just need to store information about this right now.
+            if (desc.callbackDesc.callback)
             {
-                destroyInstance(output);
-                return extensionCreateResult;
+                output->m_validationCallback = desc.callbackDesc;
+                output->m_validationCallbackMessenger = (void*)enableInternalAPIMessagePolling; //Use as boolean to indicate that a custom callback was set
+            }
+            else
+            {
+                output->m_validationCallback = { &internal::dummyValidationCallback, nullptr };
+                output->m_validationCallbackMessenger = (void*)0;
+            }
+
+            //Attempt to create factory
+            IDXGIFactory* factory = nullptr;
+            const HRESULT factoryCreateResult = CreateDXGIFactory2(factoryFlags, IID_PPV_ARGS(&factory));
+            if (FAILED(factoryCreateResult))
+            {
+                llri::destroyInstance(output);
+                return internal::mapHRESULT(factoryCreateResult);
+            }
+
+            //Store factory and return result
+            output->m_ptr = factory;
+            *instance = output;
+            return result::Success;
+        }
+
+        void destroyInstance(Instance* instance)
+        {
+            if (!instance)
+                return;
+
+            for (auto& [ptr, adapter] : instance->m_cachedAdapters)
+                delete adapter;
+
+            if (instance->m_debugAPI)
+                static_cast<ID3D12Debug*>(instance->m_debugAPI)->Release();
+
+            if (instance->m_debugGPU)
+                static_cast<ID3D12Debug1*>(instance->m_debugGPU)->Release();
+
+            delete instance;
+        }
+
+        void pollAPIMessages(const validation_callback_desc& validation, void* messenger)
+        {
+            if (messenger != nullptr && messenger != (void*)1)
+            {
+                ID3D12InfoQueue* iq = static_cast<ID3D12InfoQueue*>(messenger);
+                const auto numMsg = iq->GetNumStoredMessages();
+                
+                for (UINT64 i = 0; i < numMsg; ++i)
+                {
+                    SIZE_T messageLength = 0;
+                    iq->GetMessage(i, NULL, &messageLength);
+                    
+                    D3D12_MESSAGE* pMessage = (D3D12_MESSAGE*)malloc(messageLength);
+                    iq->GetMessage(i, pMessage, &messageLength);
+                    validation(internal::mapSeverity(pMessage->Severity), validation_callback_source::InternalAPI, pMessage->pDescription);
+                    
+                    free(pMessage);
+                }
+
+                iq->ClearStoredMessages();
             }
         }
-
-        //Attempt to create factory
-        IDXGIFactory* factory = nullptr;
-        const HRESULT factoryCreateResult = CreateDXGIFactory2(factoryFlags, IID_PPV_ARGS(&factory));
-        if (FAILED(factoryCreateResult))
-        {
-            destroyInstance(output);
-            return internal::mapHRESULT(factoryCreateResult);
-        }
-
-        //Store factory and return result
-        output->m_ptr = factory;
-        *instance = output;
-        return result::Success;
     }
 
-    void destroyInstance(Instance* instance)
+    result Instance::impl_enumerateAdapters(std::vector<Adapter*>* adapters)
     {
-        if (!instance)
-            return;
-
-        for (auto& [ptr, adapter] : instance->m_cachedAdapters)
-            delete adapter;
-
-        if (instance->m_debugAPI)
-            static_cast<ID3D12Debug*>(instance->m_debugAPI)->Release();
-
-        if (instance->m_debugGPU)
-            static_cast<ID3D12Debug1*>(instance->m_debugGPU)->Release();
-
-        delete instance;
-    }
-
-    result Instance::enumerateAdapters(std::vector<Adapter*>* adapters)
-    {
-        if (adapters == nullptr)
-            return result::ErrorInvalidUsage;
-
         adapters->clear();
 
         //Clear internal pointers, lost adapters will have a nullptr internally
@@ -126,6 +182,8 @@ namespace legion::graphics::llri
             {
                 Adapter* adapter = new Adapter();
                 adapter->m_ptr = dxgiAdapter;
+                adapter->m_validationCallback = m_validationCallback;
+                adapter->m_validationCallbackMessenger = m_validationCallbackMessenger;
 
                 m_cachedAdapters[(void*)luid] = adapter;
                 adapters->push_back(adapter);
@@ -137,18 +195,10 @@ namespace legion::graphics::llri
         return result::Success;
     }
 
-    result Instance::createDevice(const device_desc& desc, Device** device)
+    result Instance::impl_createDevice(const device_desc& desc, Device** device) const
     {
-        if (m_ptr == nullptr || device == nullptr || desc.adapter == nullptr)
-            return result::ErrorInvalidUsage;
-
-        if (desc.numExtensions > 0 && desc.extensions == nullptr)
-            return result::ErrorInvalidUsage;
-
-        if (desc.adapter->m_ptr == nullptr)
-            return result::ErrorDeviceLost;
-
-        Device* result = new Device();
+        Device* output = new Device();
+        output->m_validationCallback = m_validationCallback;
 
         D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_12_0; //12.0 is the bare minimum
 
@@ -156,16 +206,25 @@ namespace legion::graphics::llri
         HRESULT r = D3D12CreateDevice(static_cast<IDXGIAdapter*>(desc.adapter->m_ptr), featureLevel, IID_PPV_ARGS(&dx12Device));
         if (FAILED(r))
         {
-            destroyDevice(result);
+            destroyDevice(output);
             return internal::mapHRESULT(r);
         }
+        output->m_ptr = dx12Device;
 
-        result->m_ptr = dx12Device;
-        *device = result;
+        if (m_validationCallbackMessenger)
+        {
+            ID3D12InfoQueue* iq = nullptr;
+            r = dx12Device->QueryInterface(IID_PPV_ARGS(&iq));
+
+            if (SUCCEEDED(r))
+                output->m_validationCallbackMessenger = iq;
+        }
+
+        *device = output;
         return result::Success;
     }
 
-    void Instance::destroyDevice(Device* device)
+    void Instance::impl_destroyDevice(Device* device) const
     {
         if (!device)
             return;
@@ -176,14 +235,8 @@ namespace legion::graphics::llri
         delete device;
     }
 
-    result Adapter::queryInfo(adapter_info* info) const
+    result Adapter::impl_queryInfo(adapter_info* info) const
     {
-        if (info == nullptr)
-            return result::ErrorInvalidUsage;
-
-        if (m_ptr == nullptr)
-            return result::ErrorDeviceRemoved;
-
         DXGI_ADAPTER_DESC1 desc;
         static_cast<IDXGIAdapter1*>(m_ptr)->GetDesc1(&desc);
 
@@ -204,14 +257,8 @@ namespace legion::graphics::llri
         return result::Success;
     }
 
-    result Adapter::queryFeatures(adapter_features* features) const
+    result Adapter::impl_queryFeatures(adapter_features* features) const
     {
-        if (features == nullptr)
-            return result::ErrorInvalidUsage;
-
-        if (m_ptr == nullptr)
-            return result::ErrorDeviceRemoved;
-
         HRESULT level12_0 = D3D12CreateDevice(static_cast<IDXGIAdapter*>(m_ptr), D3D_FEATURE_LEVEL_12_0, __uuidof(ID3D12Device), nullptr);
         if (level12_0 == E_FAIL)
             return result::ErrorIncompatibleDriver;
@@ -222,22 +269,24 @@ namespace legion::graphics::llri
         HRESULT level12_1 = D3D12CreateDevice(static_cast<IDXGIAdapter*>(m_ptr), D3D_FEATURE_LEVEL_12_0, __uuidof(ID3D12Device), nullptr);
         HRESULT level12_2 = D3D12CreateDevice(static_cast<IDXGIAdapter*>(m_ptr), D3D_FEATURE_LEVEL_12_0, __uuidof(ID3D12Device), nullptr);
 
-        adapter_features result;
+        adapter_features output;
 
         //Set all the information in a structured way here
 
-        *features = result;
+        *features = output;
         return result::Success;
     }
 
-    bool Adapter::queryExtensionSupport(const adapter_extension_type& type) const
+    result Adapter::impl_queryExtensionSupport(const adapter_extension_type& type, bool* supported) const
     {
+        *supported = false;
+
         switch (type)
         {
-            default:
-                break;
+        default:
+            break;
         }
 
-        return false;
+        return result::Success;
     }
 }

--- a/legion/engine/llri-dx/source.cpp
+++ b/legion/engine/llri-dx/source.cpp
@@ -86,7 +86,7 @@ namespace legion::graphics::llri
             else
             {
                 output->m_validationCallback = { &internal::dummyValidationCallback, nullptr };
-                output->m_validationCallbackMessenger = (void*)0;
+                output->m_validationCallbackMessenger = nullptr;
             }
 
             //Attempt to create factory

--- a/legion/engine/llri-dx/source.cpp
+++ b/legion/engine/llri-dx/source.cpp
@@ -35,7 +35,7 @@ namespace legion::graphics::llri
 
     namespace detail
     {
-        result createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling)
+        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling)
         {
             auto* output = new Instance();
             UINT factoryFlags = 0;
@@ -104,7 +104,7 @@ namespace legion::graphics::llri
             return result::Success;
         }
 
-        void destroyInstance(Instance* instance)
+        void impl_destroyInstance(Instance* instance)
         {
             if (!instance)
                 return;
@@ -121,7 +121,7 @@ namespace legion::graphics::llri
             delete instance;
         }
 
-        void pollAPIMessages(const validation_callback_desc& validation, void* messenger)
+        void impl_pollAPIMessages(const validation_callback_desc& validation, void* messenger)
         {
             if (messenger != nullptr && messenger != (void*)1)
             {

--- a/legion/engine/llri-dx/utils.cpp
+++ b/legion/engine/llri-dx/utils.cpp
@@ -36,6 +36,8 @@ namespace legion::graphics::llri
                     break;
                 case E_FAIL:
                     break;
+                case E_NOINTERFACE:
+                    return result::ErrorExtensionNotSupported;
                 case E_INVALIDARG:
                     return result::ErrorInvalidUsage;
                 case E_OUTOFMEMORY:

--- a/legion/engine/llri-vk/instance_extensions.cpp
+++ b/legion/engine/llri-vk/instance_extensions.cpp
@@ -3,12 +3,14 @@
 
 namespace legion::graphics::llri
 {
-    bool queryInstanceExtensionSupport(const instance_extension_type& type)
+    namespace detail
     {
-        auto layers = internal::queryAvailableLayers();
-
-        switch (type)
+        [[nodiscard]] bool queryInstanceExtensionSupport(const instance_extension_type& type)
         {
+            auto layers = internal::queryAvailableLayers();
+
+            switch (type)
+            {
             case instance_extension_type::APIValidation:
             {
                 return layers.find(internal::nameHash("VK_LAYER_KHRONOS_validation")) != layers.end();
@@ -17,8 +19,9 @@ namespace legion::graphics::llri
             {
                 return true;
             }
-        }
+            }
 
-        return false;
+            return false;
+        }
     }
 }

--- a/legion/engine/llri-vk/source.cpp
+++ b/legion/engine/llri-vk/source.cpp
@@ -114,7 +114,8 @@ namespace legion::graphics::llri
             }
 
             //Add the debug utils extension for the API callback
-            bool shouldConstructValidationMessenger = false;
+            result->m_shouldConstructValidationCallbackMessenger = false;
+            result->m_validationCallbackMessenger = nullptr;
             if (enableInternalAPIMessagePolling && desc.callbackDesc.callback)
             {
                 auto available = internal::queryAvailableExtensions();
@@ -123,7 +124,7 @@ namespace legion::graphics::llri
                 if (available.find(internal::nameHash(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) != available.end())
                 {
                     extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-                    shouldConstructValidationMessenger = true;
+                    result->m_shouldConstructValidationCallbackMessenger = true;
                 }
             }
 
@@ -142,7 +143,7 @@ namespace legion::graphics::llri
             result->m_ptr = vulkanInstance;
 
             //Create debug utils callback
-            if (desc.callbackDesc.callback && shouldConstructValidationMessenger)
+            if (result->m_shouldConstructValidationCallbackMessenger)
             {
                 result->m_validationCallback = desc.callbackDesc;
 
@@ -194,7 +195,7 @@ namespace legion::graphics::llri
             delete instance;
         }
 
-        void impl_pollAPIMessages(const validation_callback_desc& validation, void* messenger)
+        void impl_pollAPIMessages(const validation_callback_desc& validation, messenger_type* messenger)
         {
             //Empty because vulkan uses a callback system
             //suppress unused parameter warnings

--- a/legion/engine/llri-vk/source.cpp
+++ b/legion/engine/llri-vk/source.cpp
@@ -157,12 +157,12 @@ namespace legion::graphics::llri
 
                 const vk::DebugUtilsMessengerCreateInfoEXT debugUtilsCi{ {}, severity, types, &internal::debugCallback, &result->m_validationCallback };
 
-                const auto func = (PFN_vkCreateDebugUtilsMessengerEXT)vulkanInstance.getProcAddr("vkCreateDebugUtilsMessengerEXT");
+                const auto func = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(vulkanInstance.getProcAddr("vkCreateDebugUtilsMessengerEXT"));
                 if (func)
                 {
-                    auto vkCi = (VkDebugUtilsMessengerCreateInfoEXT)debugUtilsCi;
+                    auto vkCi = static_cast<VkDebugUtilsMessengerCreateInfoEXT>(debugUtilsCi);
                     VkDebugUtilsMessengerEXT messenger;
-                    func((VkInstance)vulkanInstance, &vkCi, nullptr, &messenger);
+                    func(static_cast<VkInstance>(vulkanInstance), &vkCi, nullptr, &messenger);
 
                     result->m_validationCallbackMessenger = messenger;
                 }
@@ -176,14 +176,14 @@ namespace legion::graphics::llri
         {
             if (!instance)
                 return;
-            const vk::Instance vkInstance = (VkInstance)instance->m_ptr;
+            const vk::Instance vkInstance = static_cast<VkInstance>(instance->m_ptr);
 
             //Destroy debug messenger if possible
             if (instance->m_validationCallbackMessenger)
             {
-                const auto func = (PFN_vkDestroyDebugUtilsMessengerEXT)vkInstance.getProcAddr("vkDestroyDebugUtilsMessengerEXT");
+                const auto func = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(vkInstance.getProcAddr("vkDestroyDebugUtilsMessengerEXT"));
                 if (func != nullptr)
-                    func((VkInstance)vkInstance, (VkDebugUtilsMessengerEXT)instance->m_validationCallbackMessenger, nullptr);
+                    func(static_cast<VkInstance>(vkInstance), static_cast<VkDebugUtilsMessengerEXT>(instance->m_validationCallbackMessenger), nullptr);
             }
 
             for (auto& [ptr, adapter] : instance->m_cachedAdapters)

--- a/legion/engine/llri-vk/source.cpp
+++ b/legion/engine/llri-vk/source.cpp
@@ -64,7 +64,7 @@ namespace legion::graphics::llri
 
     namespace detail
     {
-        result createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling)
+        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling)
         {
             auto* result = new Instance();
 
@@ -172,7 +172,7 @@ namespace legion::graphics::llri
             return result::Success;
         }
 
-        void destroyInstance(Instance* instance)
+        void impl_destroyInstance(Instance* instance)
         {
             if (!instance)
                 return;
@@ -194,7 +194,7 @@ namespace legion::graphics::llri
             delete instance;
         }
 
-        void pollAPIMessages(const validation_callback_desc& validation, void* messenger)
+        void impl_pollAPIMessages(const validation_callback_desc& validation, void* messenger)
         {
             //Empty because vulkan uses a callback system
             //suppress unused parameter warnings

--- a/legion/engine/llri/instance_extensions.hpp
+++ b/legion/engine/llri/instance_extensions.hpp
@@ -23,18 +23,7 @@ namespace legion::graphics::llri
     /**
      * @brief Converts an instance_extension_type to a string to aid in debug logging.
     */
-    constexpr const char* to_string(const instance_extension_type& result)
-    {
-        switch (result)
-        {
-            case instance_extension_type::APIValidation:
-                return "APIValidation";
-            case instance_extension_type::GPUValidation:
-                return "GPUValidation";
-        }
-
-        return "Invalid instance_extension_type value";
-    }
+    constexpr const char* to_string(const instance_extension_type& result);
 
     /**
      * @brief Enable or disable API-side validation.
@@ -81,6 +70,11 @@ namespace legion::graphics::llri
         instance_extension(const instance_extension_type& type, const api_validation_ext& ext) : type(type), apiValidation(ext) { }
         instance_extension(const instance_extension_type& type, const gpu_validation_ext& ext) : type(type), gpuValidation(ext) { }
     };
+
+    namespace detail
+    {
+        [[nodiscard]] bool queryInstanceExtensionSupport(const instance_extension_type& type);
+    }
 
     /**
      * @brief Queries the support of the given extension.

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -171,7 +171,7 @@ namespace legion::graphics::llri
     /**
      * @brief The debug callback function, this function passes a severity (info, warning, error, etc), a source (LLRI validation or Internal API message), the message, and some userdata that can be set in the validation_callback_desc.
     */
-    typedef void (FnValidationCallback)(
+    using FnValidationCallback = void (
         const validation_callback_severity& severity,
         const validation_callback_source& source,
         const char* message,

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -241,13 +241,14 @@ namespace legion::graphics::llri
         result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling);
         void impl_destroyInstance(Instance* instance);
 
+        using messenger_type = void;
         /**
          * @brief Polls API messages, called if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING is set to 1.
          * Used internally only
          * @param validation The validation function / userdata
          * @param messenger This value may differ depending on the function that is calling it, the most relevant messenger will be picked.
         */
-        void impl_pollAPIMessages(const validation_callback_desc& validation, void* messenger);
+        void impl_pollAPIMessages(const validation_callback_desc& validation, messenger_type* messenger);
     }
 
     /**
@@ -317,6 +318,7 @@ namespace legion::graphics::llri
         void* m_debugGPU = nullptr;
 
         validation_callback_desc m_validationCallback;
+        bool m_shouldConstructValidationCallbackMessenger;
         void* m_validationCallbackMessenger = nullptr; //Allows API to store their callback messenger if needed
 
         std::map<void*, Adapter*> m_cachedAdapters;

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -7,23 +7,23 @@
 #include <llri/instance_extensions.hpp>
 #include <llri/adapter_extensions.hpp>
 
-#ifndef LLRI_ENABLE_VALIDATION
+#if defined(DOXY_EXCLUDE)
 /**
- * @brief Before including LLRI, define LLRI_ENABLE_VALIDATION as 0 to disable all LLRI validation.
+ * @def LLRI_DISABLE_VALIDATION
+ * @brief Before including LLRI, define LLRI_DISABLE_VALIDATION to disable all LLRI validation.
  * This applies to all validation done by LLRI (not internal API validation), such as nullptr checks on parameters.
  * Disabling LLRI validation may cause API runtime errors if incorrect parameters are passed, but the reduced checks could improve performance.
  *
  * Disabling LLRI validation will also mean that LLRI will not return ErrorInvalidUsage and ErrorDeviceLost where it normally would if incorrect parameters are passed, but the internal API may still return these codes if it fails to operate.
  */
-#define LLRI_ENABLE_VALIDATION 1
-#endif
+#define LLRI_DISABLE_VALIDATION
 
-#ifndef LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
  /**
-  * @brief Before including LLRI, define LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING as 0 to disable internal API message polling.
+  * @def LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+  * @brief Before including LLRI, define LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING to disable internal API message polling.
   * Internal API message polling can be costly and disabling it can help improve performance, but internal API messages might not be forwarded.
   */
-#define LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING 1
+#define LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
 #endif
 
 namespace legion::graphics::llri
@@ -226,7 +226,7 @@ namespace legion::graphics::llri
         /**
          * @brief Describes the optional validation callback. callbackDesc.callback can be nullptr in which case no callbacks will be sent.
          *
-         * Callbacks may or may not be sent depending on the parameters used. If LLRI_ENABLE_VALIDATION is set to 0, no LLRI validation messages will be sent. If LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING is set to 0, then no internal API messages will be forwarded.
+         * Callbacks may or may not be sent depending on the parameters used. If LLRI_DISABLE_VALIDATION is defined, no LLRI validation messages will be sent. If LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING is defined, then no internal API messages will be forwarded.
          *
          * Furthermore, to enable internal API messages, api_validation_ext and/or gpu_validation_ext should be enabled and part of the extensions array.
         */
@@ -243,7 +243,7 @@ namespace legion::graphics::llri
 
         using messenger_type = void;
         /**
-         * @brief Polls API messages, called if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING is set to 1.
+         * @brief Polls API messages, only called if LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING is not defined.
          * Used internally only
          * @param validation The validation function / userdata
          * @param messenger This value may differ depending on the function that is calling it, the most relevant messenger will be picked.

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -117,7 +117,7 @@ namespace legion::graphics::llri
     /**
      * @brief Describes the severity of a callback message.
     */
-    enum class validation_callback_severity
+    enum struct validation_callback_severity
     {
         /**
          * @brief Provides extra, often excessive information about API calls, diagnostics, support, etc.
@@ -149,7 +149,7 @@ namespace legion::graphics::llri
     /**
      * @brief Describes the source of the validation callback message.
     */
-    enum class validation_callback_source
+    enum struct validation_callback_source
     {
         /**
          * @brief The message came from the LLRI API directly.

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -171,7 +171,7 @@ namespace legion::graphics::llri
     /**
      * @brief The debug callback function, this function passes a severity (info, warning, error, etc), a source (LLRI validation or Internal API message), the message, and some userdata that can be set in the validation_callback_desc.
     */
-    using FnValidationCallback = void (
+    using validation_callback = void (
         const validation_callback_severity& severity,
         const validation_callback_source& source,
         const char* message,
@@ -192,7 +192,7 @@ namespace legion::graphics::llri
          * @brief The callback, the function passed must conform to the FnValidationCallback definition.
          * This value CAN be nullptr, in which case no validation messages will be sent.
         */
-        FnValidationCallback* callback;
+        validation_callback* callback;
         /**
          * @brief Optional user data pointer. Not used internally by the API but it's passed around and sent along the callback.
         */

--- a/legion/engine/llri/llri.vcxproj
+++ b/legion/engine/llri/llri.vcxproj
@@ -125,6 +125,7 @@ del /q ".\xcopyexclude"</Command>
     <ClInclude Include="adapter_extensions.hpp" />
     <ClInclude Include="instance_extensions.hpp" />
     <ClInclude Include="llri.hpp" />
+    <ClInclude Include="llri_impl.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/legion/engine/llri/llri.vcxproj.filters
+++ b/legion/engine/llri/llri.vcxproj.filters
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
@@ -18,6 +14,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="adapter_extensions.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="llri_impl.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/legion/engine/llri/llri_impl.hpp
+++ b/legion/engine/llri/llri_impl.hpp
@@ -126,17 +126,17 @@ namespace legion::graphics::llri
 #endif
 
 #if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
-        const auto r =  detail::createInstance(desc, instance, true);
-        detail::pollAPIMessages((*instance)->m_validationCallback, (*instance)->m_validationCallbackMessenger);
+        const auto r =  detail::impl_createInstance(desc, instance, true);
+        detail::impl_pollAPIMessages((*instance)->m_validationCallback, (*instance)->m_validationCallbackMessenger);
         return r;
 #else
-        return detail::createInstance(desc, instance, false);
+        return detail::impl_createInstance(desc, instance, false);
 #endif
     }
 
     inline void destroyInstance(Instance* instance)
     {
-        detail::destroyInstance(instance);
+        detail::impl_destroyInstance(instance);
         //Can't do any polling after the instance is destroyed
     }
 
@@ -152,7 +152,7 @@ namespace legion::graphics::llri
 
 #if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_enumerateAdapters(adapters);
-        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
 #else
         return impl_enumerateAdapters(adapters);
@@ -189,7 +189,7 @@ namespace legion::graphics::llri
 
 #if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_createDevice(desc, device);
-        detail::pollAPIMessages((*device)->m_validationCallback, (*device)->m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages((*device)->m_validationCallback, (*device)->m_validationCallbackMessenger);
         return r;
 #else
         return impl_createDevice(desc, device);
@@ -202,7 +202,7 @@ namespace legion::graphics::llri
 
 #if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
         //Can't use device messenger here because the device is destroyed
-        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
 #endif
     }
 
@@ -224,7 +224,7 @@ namespace legion::graphics::llri
 
 #if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_queryInfo(info);
-        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
 #else
         return impl_queryInfo(info);
@@ -249,7 +249,7 @@ namespace legion::graphics::llri
 
 #if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_queryFeatures(features);
-        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
 #else
         return impl_queryFeatures(features);
@@ -274,7 +274,7 @@ namespace legion::graphics::llri
 
 #if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_queryExtensionSupport(type, supported);
-        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
 #else
         return impl_queryExtensionSupport(type, supported);

--- a/legion/engine/llri/llri_impl.hpp
+++ b/legion/engine/llri/llri_impl.hpp
@@ -1,0 +1,283 @@
+#pragma once
+
+namespace legion::graphics::llri
+{
+    constexpr inline const char* to_string(const result& result)
+    {
+        switch (result)
+        {
+        case result::Success:
+            return "Success";
+        case result::Timeout:
+            return "Timeout";
+        case result::ErrorUnknown:
+            return "ErrorUnknown";
+        case result::ErrorInvalidUsage:
+            return "ErrorInvalidUsage";
+        case result::ErrorFeatureNotSupported:
+            return "ErrorFeatureNotSupported";
+        case result::ErrorExtensionNotSupported:
+            return "ErrorExtensionNotSupported";
+        case result::ErrorDeviceHung:
+            return "ErrorDeviceHung";
+        case result::ErrorDeviceLost:
+            return "ErrorDeviceLost";
+        case result::ErrorDeviceRemoved:
+            return "ErrorDeviceRemoved";
+        case result::ErrorDriverFailure:
+            return "ErrorDriverFailure";
+        case result::NotReady:
+            return "NotReady";
+        case result::ErrorOutOfHostMemory:
+            return "ErrorOutOfHostMemory";
+        case result::ErrorOutOfDeviceMemory:
+            return "ErrorOutOfDeviceMemory";
+        case result::ErrorInitializationFailed:
+            return "ErrorInitializationFailed";
+        case result::ErrorIncompatibleDriver:
+            return "ErrorIncompatibleDriver";
+        }
+
+        return "Invalid result value";
+    }
+
+    constexpr inline const char* to_string(const validation_callback_severity& severity)
+    {
+        switch (severity)
+        {
+        case validation_callback_severity::Verbose:
+            return "Verbose";
+        case validation_callback_severity::Info:
+            return "Info";
+        case validation_callback_severity::Warning:
+            return "Warning";
+        case validation_callback_severity::Error:
+            return "Error";
+        case validation_callback_severity::Corruption:
+            return "Corruption";
+        }
+
+        return "Invalid validation_callback_severity value";
+    }
+
+    constexpr inline const char* to_string(const validation_callback_source& source)
+    {
+        switch (source)
+        {
+        case validation_callback_source::Validation:
+            return "Validation";
+        case validation_callback_source::InternalAPI:
+            return "InternalAPI";
+        }
+
+        return "Invalid validation_callback_source value";
+    }
+
+    constexpr inline const char* to_string(const adapter_type& type)
+    {
+        switch (type)
+        {
+        case adapter_type::Other:
+            return "Other";
+        case adapter_type::Integrated:
+            return "Integrated";
+        case adapter_type::Discrete:
+            return "Discrete";
+        case adapter_type::Virtual:
+            return "Virtual";
+        }
+
+        return "Invalid adapter_type value";
+    }
+
+    constexpr inline const char* to_string(const instance_extension_type& result)
+    {
+        switch (result)
+        {
+        case instance_extension_type::APIValidation:
+            return "APIValidation";
+        case instance_extension_type::GPUValidation:
+            return "GPUValidation";
+        }
+
+        return "Invalid instance_extension_type value";
+    }
+
+    [[nodiscard]] inline bool queryInstanceExtensionSupport(const instance_extension_type& type)
+    {
+        return detail::queryInstanceExtensionSupport(type);
+    }
+
+    inline result createInstance(const instance_desc& desc, Instance** instance)
+    {
+#if LLRI_ENABLE_VALIDATION
+        if (instance == nullptr)
+        {
+            if (desc.callbackDesc.callback)
+                desc.callbackDesc(validation_callback_severity::Error, validation_callback_source::Validation, "createInstance() returned ErrorInvalidUsage because the passed instance parameter was nullptr.");
+            return result::ErrorInvalidUsage;
+        }
+        if (desc.numExtensions > 0 && desc.extensions == nullptr)
+        {
+            if (desc.callbackDesc.callback)
+                desc.callbackDesc(validation_callback_severity::Error, validation_callback_source::Validation, "createInstance() returned ErrorInvalidUsage because desc.numExtensions was more than 0 but desc.extensions was nullptr.");
+            return result::ErrorInvalidUsage;
+        }
+#endif
+
+#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+        const auto r =  detail::createInstance(desc, instance, true);
+        detail::pollAPIMessages((*instance)->m_validationCallback, (*instance)->m_validationCallbackMessenger);
+        return r;
+#else
+        return detail::createInstance(desc, instance, false);
+#endif
+    }
+
+    inline void destroyInstance(Instance* instance)
+    {
+        detail::destroyInstance(instance);
+        //Can't do any polling after the instance is destroyed
+    }
+
+    inline result Instance::enumerateAdapters(std::vector<Adapter*>* adapters)
+    {
+#if LLRI_ENABLE_VALIDATION
+        if (adapters == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Instance::enumerateAdapters() returned ErrorInvalidUsage because the passed adapters parameter was nullptr.");
+            return result::ErrorInvalidUsage;
+        }
+#endif
+
+#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+        const auto r = impl_enumerateAdapters(adapters);
+        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        return r;
+#else
+        return impl_enumerateAdapters(adapters);
+#endif
+    }
+
+    inline result Instance::createDevice(const device_desc& desc, Device** device) const
+    {
+#if LLRI_ENABLE_VALIDATION
+        if (device == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Instance::createDevice() returned ErrorInvalidUsage because the passed device parameter was nullptr.");
+            return result::ErrorInvalidUsage;
+        }
+
+        if (desc.adapter == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Instance::createDevice() returned ErrorInvalidUsage because desc.adapter was nullptr.");
+            return result::ErrorInvalidUsage;
+        }
+
+        if (desc.numExtensions > 0 && desc.extensions == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Instance::createDevice() returned ErrorInvalidUsage because desc.numExtensions was more than 0 but desc.extensions was nullptr.");
+            return result::ErrorInvalidUsage;
+        }
+
+        if (desc.adapter->m_ptr == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Instance::createDevice() returned ErrorDeviceLost because the passed adapter has a nullptr internal handle which usually indicates a lost device.");
+            return result::ErrorDeviceLost;
+        }
+#endif
+
+#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+        const auto r = impl_createDevice(desc, device);
+        detail::pollAPIMessages((*device)->m_validationCallback, (*device)->m_validationCallbackMessenger);
+        return r;
+#else
+        return impl_createDevice(desc, device);
+#endif
+    }
+
+    inline void Instance::destroyDevice(Device* device) const
+    {
+        impl_destroyDevice(device);
+
+#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+        //Can't use device messenger here because the device is destroyed
+        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+#endif
+    }
+
+    inline result Adapter::queryInfo(adapter_info* info) const
+    {
+#if LLRI_ENABLE_VALIDATION
+        if (info == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryInfo() returned ErrorInvalidUsage because the passed info parameter was nullptr.");
+            return result::ErrorInvalidUsage;
+        }
+
+        if (m_ptr == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryInfo() returned ErrorDeviceLost because the passed adapter has a nullptr internal handle which usually indicates a lost device.");
+            return result::ErrorDeviceLost;
+        }
+#endif
+
+#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+        const auto r = impl_queryInfo(info);
+        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        return r;
+#else
+        return impl_queryInfo(info);
+#endif
+    }
+
+    inline result Adapter::queryFeatures(adapter_features* features) const
+    {
+#if LLRI_ENABLE_VALIDATION
+        if (features == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryFeatures() returned ErrorInvalidUsage because the passed features parameter was nullptr.");
+            return result::ErrorInvalidUsage;
+        }
+
+        if (m_ptr == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryFeatures() returned ErrorDeviceLost because the passed adapter has a nullptr internal handle which usually indicates a lost device.");
+            return result::ErrorDeviceLost;
+        }
+#endif
+
+#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+        const auto r = impl_queryFeatures(features);
+        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        return r;
+#else
+        return impl_queryFeatures(features);
+#endif
+    }
+
+    inline result Adapter::queryExtensionSupport(const adapter_extension_type& type, bool* supported) const
+    {
+#if LLRI_ENABLE_VALIDATION
+        if (supported == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryExtensionSupport() returned ErrorInvalidUsage because the passed supported parameter was nullptr.");
+            return result::ErrorInvalidUsage;
+        }
+
+        if (m_ptr == nullptr)
+        {
+            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryExtensionSupport() returned ErrorDeviceLost because the passed adapter has a nullptr internal handle which usually indicates a lost device.");
+            return result::ErrorDeviceLost;
+        }
+#endif
+
+#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+        const auto r = impl_queryExtensionSupport(type, supported);
+        detail::pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        return r;
+#else
+        return impl_queryExtensionSupport(type, supported);
+#endif
+    }
+}

--- a/legion/engine/llri/llri_impl.hpp
+++ b/legion/engine/llri/llri_impl.hpp
@@ -110,7 +110,7 @@ namespace legion::graphics::llri
 
     inline result createInstance(const instance_desc& desc, Instance** instance)
     {
-#if LLRI_ENABLE_VALIDATION
+#ifndef LLRI_DISABLE_VALIDATION
         if (instance == nullptr)
         {
             if (desc.callbackDesc.callback)
@@ -125,7 +125,7 @@ namespace legion::graphics::llri
         }
 #endif
 
-#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r =  detail::impl_createInstance(desc, instance, true);
         detail::impl_pollAPIMessages((*instance)->m_validationCallback, (*instance)->m_validationCallbackMessenger);
         return r;
@@ -142,7 +142,7 @@ namespace legion::graphics::llri
 
     inline result Instance::enumerateAdapters(std::vector<Adapter*>* adapters)
     {
-#if LLRI_ENABLE_VALIDATION
+#ifndef LLRI_DISABLE_VALIDATION
         if (adapters == nullptr)
         {
             m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Instance::enumerateAdapters() returned ErrorInvalidUsage because the passed adapters parameter was nullptr.");
@@ -150,7 +150,7 @@ namespace legion::graphics::llri
         }
 #endif
 
-#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_enumerateAdapters(adapters);
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
@@ -161,7 +161,7 @@ namespace legion::graphics::llri
 
     inline result Instance::createDevice(const device_desc& desc, Device** device) const
     {
-#if LLRI_ENABLE_VALIDATION
+#ifndef LLRI_DISABLE_VALIDATION
         if (device == nullptr)
         {
             m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Instance::createDevice() returned ErrorInvalidUsage because the passed device parameter was nullptr.");
@@ -187,7 +187,7 @@ namespace legion::graphics::llri
         }
 #endif
 
-#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_createDevice(desc, device);
         detail::impl_pollAPIMessages((*device)->m_validationCallback, (*device)->m_validationCallbackMessenger);
         return r;
@@ -200,7 +200,7 @@ namespace legion::graphics::llri
     {
         impl_destroyDevice(device);
 
-#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
         //Can't use device messenger here because the device is destroyed
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
 #endif
@@ -208,7 +208,7 @@ namespace legion::graphics::llri
 
     inline result Adapter::queryInfo(adapter_info* info) const
     {
-#if LLRI_ENABLE_VALIDATION
+#ifndef LLRI_DISABLE_VALIDATION
         if (info == nullptr)
         {
             m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryInfo() returned ErrorInvalidUsage because the passed info parameter was nullptr.");
@@ -222,7 +222,7 @@ namespace legion::graphics::llri
         }
 #endif
 
-#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_queryInfo(info);
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
@@ -233,7 +233,7 @@ namespace legion::graphics::llri
 
     inline result Adapter::queryFeatures(adapter_features* features) const
     {
-#if LLRI_ENABLE_VALIDATION
+#ifndef LLRI_DISABLE_VALIDATION
         if (features == nullptr)
         {
             m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryFeatures() returned ErrorInvalidUsage because the passed features parameter was nullptr.");
@@ -247,7 +247,7 @@ namespace legion::graphics::llri
         }
 #endif
 
-#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_queryFeatures(features);
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
@@ -258,7 +258,7 @@ namespace legion::graphics::llri
 
     inline result Adapter::queryExtensionSupport(const adapter_extension_type& type, bool* supported) const
     {
-#if LLRI_ENABLE_VALIDATION
+#ifndef LLRI_DISABLE_VALIDATION
         if (supported == nullptr)
         {
             m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryExtensionSupport() returned ErrorInvalidUsage because the passed supported parameter was nullptr.");
@@ -272,7 +272,7 @@ namespace legion::graphics::llri
         }
 #endif
 
-#if LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
         const auto r = impl_queryExtensionSupport(type, supported);
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;


### PR DESCRIPTION
This PR introduces the validation message callback. This callback can be used to receive messages from both the LLRI API and the internal API (Vulkan/DirectX). 

To accommodate for this, all API functions have been split into a pre-implementation function (llri_impl.hpp) where validation *can* be applied, and their implementation functions (impl_function()) which get implemented for each API. To prevent this feature from introducing potential performance overhead, the pre-implementation functions are inlined, and the feature introduces the LLRI_ENABLE_VALIDATION and LLRI_ENABLE_INTERNAL_API_MESSAGE_POLLING preprocessor flags that can help prevent LLRI from running unneeded checks in release builds.

Other than those two flags, the feature introduces:

**1 new structure**
* **validation_callback_desc** Which is passed into the instance_desc structure and allows the user to pass a callback function and a user data pointer. Passing a callback is optional, the API will simply not forward callback messages if no callback function is passed.

**2 new enum types**
* **validation_callback_severity** Describes the severity of the message (Verbose, Info, Warning, Error, Corruption)
* **validation_callback_source** Describes the source of the message (LLRI Validation or the InternalAPI)

All enum types come with matching to_string() functions for ease of debugging.

**1 new function pointer**
* **validation_callback** Is used to receive callback messages from LLRI and its internal API. It passes a severity, source, message, and optionally userdata. 