### PR TITLE
bugfix/vulkan-nullptr-callback-crash

### DIFF
--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -56,6 +56,8 @@ namespace legion::graphics::llri
 
             return VK_FALSE;
         }
+
+        void dummyValidationCallback(const validation_callback_severity&, const validation_callback_source&, const char*, void*) { }
     }
 
     namespace detail
@@ -166,6 +168,11 @@ namespace legion::graphics::llri
 
                     result->m_validationCallbackMessenger = messenger;
                 }
+            }
+            else
+            {
+                result->m_validationCallback = { &internal::dummyValidationCallback, nullptr };
+                result->m_validationCallbackMessenger = nullptr;
             }
 
             *instance = result;


### PR DESCRIPTION
Vulkan crashed whenever a nullptr callback was passed because no dummy callback was created in place.