### PR TITLE
Made the LLRI namespace configurable

### DIFF
--- a/applications/samples/000_hello_llri/source.cpp
+++ b/applications/samples/000_hello_llri/source.cpp
@@ -1,6 +1,4 @@
 #include <llri/llri.hpp>
-using namespace legion::graphics;
-
 #include <iostream>
 
 int main()

--- a/applications/samples/001_validation/source.cpp
+++ b/applications/samples/001_validation/source.cpp
@@ -7,9 +7,6 @@
 #define LLRI_DISABLE_VALIDATION
 #endif
 #include <llri/llri.hpp>
-using namespace legion::graphics;
-
-#include <cassert>
 #include <iostream>
 
 void callback(const llri::validation_callback_severity& severity, const llri::validation_callback_source& source, const char* message, void* userData)

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -11,8 +11,6 @@
 //#define LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING //uncommenting this disables internal API message polling
 #include <llri/llri.hpp>
 
-namespace llri = legion::graphics::llri;
-
 void callback(const llri::validation_callback_severity& severity, const llri::validation_callback_source& source, const char* message, void* userData)
 {
     lgn::log::severity sev = lgn::log::severity_info;

--- a/applications/unit_tests/detail/adapter.cpp
+++ b/applications/unit_tests/detail/adapter.cpp
@@ -1,6 +1,4 @@
 #include <llri/llri.hpp>
-namespace llri = legion::graphics::llri;
-
 #include <doctest/doctest.h>
 
 TEST_CASE("Adapter")

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -1,6 +1,4 @@
 #include <llri/llri.hpp>
-namespace llri = legion::graphics::llri;
-
 #include <doctest/doctest.h>
 
 TEST_SUITE("Device")

--- a/applications/unit_tests/detail/device_extensions.cpp
+++ b/applications/unit_tests/detail/device_extensions.cpp
@@ -1,6 +1,4 @@
 #include <llri/llri.hpp>
-namespace llri = legion::graphics::llri;
-
 #include <doctest/doctest.h>
 
 TEST_SUITE("Device Extensions")

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -1,6 +1,4 @@
 #include <llri/llri.hpp>
-namespace llri = legion::graphics::llri;
-
 #include <doctest/doctest.h>
 
 void dummyCallback(const llri::validation_callback_severity& sev, const llri::validation_callback_source& src, const char* message, void* userData)

--- a/applications/unit_tests/detail/instance_extensions.cpp
+++ b/applications/unit_tests/detail/instance_extensions.cpp
@@ -1,6 +1,4 @@
 #include <llri/llri.hpp>
-namespace llri = legion::graphics::llri;
-
 #include <string>
 #include <doctest/doctest.h>
 

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -1,5 +1,4 @@
 #include <llri/llri.hpp>
-namespace llri = legion::graphics::llri;
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2172,7 +2172,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = L_NODISCARD:=[[nodiscard]] DOXY_EXCLUDE DOXY_INCLUDE LEGION_FUNC:= LEGION_PURE:==0 LEGION_IMPURE:= LEGION_IMPURE_RETURN(param):= LEGION_CCONV:= L_NORETURN:=[[noreturn]] "NDOXY(...)=" "CNDOXY(...)=" L_MAYBEUNUSED:=[[maybe_unused]] L_FALLTHROUGH:=[[fallthrough]]
+PREDEFINED             = LLRI_NAMESPACE:=llri DOXY_EXCLUDE DOXY_INCLUDE "NDOXY(...)=" "CNDOXY(...)="
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/legion/engine/llri-dx/detail/adapter.cpp
+++ b/legion/engine/llri-dx/detail/adapter.cpp
@@ -1,7 +1,7 @@
 #include <llri/llri.hpp>
 #include <llri-dx/directx.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace internal
     {

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -1,7 +1,7 @@
 #include <llri/llri.hpp>
 #include <llri-dx/directx.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace internal
     {

--- a/legion/engine/llri-dx/detail/instance_extensions.cpp
+++ b/legion/engine/llri-dx/detail/instance_extensions.cpp
@@ -1,7 +1,7 @@
 #include <llri/llri.hpp>
 #include <llri-dx/directx.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace detail
     {

--- a/legion/engine/llri-dx/directx.hpp
+++ b/legion/engine/llri-dx/directx.hpp
@@ -2,7 +2,7 @@
 #include <graphics/directx/d3d12.h>
 #include <dxgi1_6.h>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace directx
     {

--- a/legion/engine/llri-dx/llri.cpp
+++ b/legion/engine/llri-dx/llri.cpp
@@ -1,6 +1,6 @@
 #include <llri/llri.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     //reserved for future use
 }

--- a/legion/engine/llri-dx/utils.cpp
+++ b/legion/engine/llri-dx/utils.cpp
@@ -1,7 +1,7 @@
 #include <llri/llri.hpp>
 #include <llri-dx/directx.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace internal
     {

--- a/legion/engine/llri-vk/detail/adapter.cpp
+++ b/legion/engine/llri-vk/detail/adapter.cpp
@@ -2,7 +2,7 @@
 #include <llri-vk/utils.hpp>
 #include <graphics/vulkan/volk.h>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace internal
     {

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -1,7 +1,7 @@
 #include <llri/llri.hpp>
 #include <llri-vk/utils.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace internal
     {

--- a/legion/engine/llri-vk/detail/instance_extensions.cpp
+++ b/legion/engine/llri-vk/detail/instance_extensions.cpp
@@ -1,7 +1,7 @@
 #include <llri/llri.hpp>
 #include <llri-vk/utils.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace detail
     {

--- a/legion/engine/llri-vk/llri.cpp
+++ b/legion/engine/llri-vk/llri.cpp
@@ -3,7 +3,7 @@
 #define VOLK_IMPLEMENTATION
 #include <graphics/vulkan/volk.h>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     //reserved for future use
 }

--- a/legion/engine/llri-vk/utils.cpp
+++ b/legion/engine/llri-vk/utils.cpp
@@ -1,7 +1,7 @@
 #include <llri/llri.hpp>
 #include <llri-vk/utils.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace internal
     {

--- a/legion/engine/llri-vk/utils.hpp
+++ b/legion/engine/llri-vk/utils.hpp
@@ -3,7 +3,7 @@
 #include <graphics/vulkan/volk.h>
 #include <unordered_map>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     namespace internal
     {

--- a/legion/engine/llri/detail/adapter.hpp
+++ b/legion/engine/llri/detail/adapter.hpp
@@ -3,7 +3,7 @@
 //are allowed as long as dependencies are upwards (e.g. adapter may include instance but not vice versa)
 #include <llri/detail/instance.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     enum struct adapter_extension_type;
 

--- a/legion/engine/llri/detail/adapter.inl
+++ b/legion/engine/llri/detail/adapter.inl
@@ -1,7 +1,7 @@
 #pragma once
 #include <llri/llri.hpp> //Recursive include technically not necessary but helps with intellisense
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     constexpr inline const char* to_string(const adapter_type& type)
     {

--- a/legion/engine/llri/detail/adapter_extensions.hpp
+++ b/legion/engine/llri/detail/adapter_extensions.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     /**
      * @brief Describes the kind of adapter extension. <br>

--- a/legion/engine/llri/detail/device.hpp
+++ b/legion/engine/llri/detail/device.hpp
@@ -3,7 +3,7 @@
 //are allowed as long as dependencies are upwards (e.g. device may include adapter but not vice versa)
 #include <llri/detail/adapter.hpp>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     /**
      * @brief Device description to be used in Instance::createDevice().

--- a/legion/engine/llri/detail/device.inl
+++ b/legion/engine/llri/detail/device.inl
@@ -1,7 +1,7 @@
 #pragma once
 #include <llri/llri.hpp> //Recursive include technically not necessary but helps with intellisense
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
 
 }

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <map>
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     enum struct result;
     struct instance_extension;

--- a/legion/engine/llri/detail/instance.inl
+++ b/legion/engine/llri/detail/instance.inl
@@ -1,7 +1,7 @@
 #pragma once
 #include <llri/llri.hpp> //Recursive include technically not necessary but helps with intellisense
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     constexpr inline const char* to_string(const validation_callback_severity& severity)
     {

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     /**
      * @brief Describes the kind of instance extension. <br>

--- a/legion/engine/llri/detail/llri.inl
+++ b/legion/engine/llri/detail/llri.inl
@@ -1,7 +1,7 @@
 #pragma once
 #include <llri/llri.hpp> //Recursive include technically not necessary but helps with intellisense
 
-namespace legion::graphics::llri
+namespace LLRI_NAMESPACE
 {
     constexpr inline const char* to_string(const result& r)
     {

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -7,7 +7,7 @@
 #if defined(DOXY_EXCLUDE)
 /**
  * @def LLRI_DISABLE_VALIDATION
- * @brief Before including LLRI, define LLRI_DISABLE_VALIDATION to disable all LLRI validation.
+ * @brief Defining LLRI_DISABLE_VALIDATION disables all LLRI validation.
  * This applies to all validation done by LLRI (not internal API validation), such as nullptr checks on parameters.
  * Disabling LLRI validation may cause API runtime errors if incorrect parameters are passed, but the reduced checks could improve performance.
  *
@@ -17,13 +17,26 @@
 
  /**
   * @def LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
-  * @brief Before including LLRI, define LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING to disable internal API message polling.
-  * Internal API message polling can be costly and disabling it can help improve performance, but internal API messages might not be forwarded.
+  * @brief Defining LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING disables all internal API message polling.
+  * Internal API message polling can be costly and disabling it can help improve performance, but internal API messages will not be forwarded.
   */
 #define LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+
+/**
+ * @def LLRI_ENABLE_LEGION_NAMESPACING
+ * @brief Defining LLRI_ENABLE_LEGION_NAMESPACING changes LLRI's namespace from llri:: to legion::graphics::llri.
+ */
+#define LLRI_ENABLE_LEGION_NAMESPACING
+#undef LLRI_ENABLE_LEGION_NAMESPACING //only defined for the doxygen comments
 #endif
 
-namespace legion::graphics::llri
+#if defined(LLRI_ENABLE_LEGION_NAMESPACING)
+#define LLRI_NAMESPACE legion::graphics::llri
+#else
+#define LLRI_NAMESPACE llri
+#endif
+
+namespace LLRI_NAMESPACE
 {
     /**
      * @brief Informative result values for llri operations.


### PR DESCRIPTION
Using LLRI_ENABLE_LEGION_NAMESPACING, users can declare that they want to use LLRI with the legion::graphics::llri namespace, otherwise LLRI defaults to a plain llri namespace.

This simplifies usage for users outside of the legion framework, and also makes the docs considerably more readable, since before this, reference links would have to write something along the likes of legion::graphics::llri::Thing.