### PR TITLE
Task/revise in-code docs

### DIFF
--- a/applications/samples/000_hello_llri/000_hello_llri.vcxproj.filters
+++ b/applications/samples/000_hello_llri/000_hello_llri.vcxproj.filters
@@ -1,22 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
-    </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="source.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
+    <ClCompile Include="source.cpp" />
   </ItemGroup>
 </Project>

--- a/applications/samples/000_hello_llri/source.cpp
+++ b/applications/samples/000_hello_llri/source.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file source.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/applications/samples/000_hello_llri/source.cpp
+++ b/applications/samples/000_hello_llri/source.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <iostream>
 

--- a/applications/samples/001_validation/001_validation.vcxproj.filters
+++ b/applications/samples/001_validation/001_validation.vcxproj.filters
@@ -1,22 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
-    </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="source.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
+    <ClCompile Include="source.cpp" />
   </ItemGroup>
 </Project>

--- a/applications/samples/001_validation/source.cpp
+++ b/applications/samples/001_validation/source.cpp
@@ -29,7 +29,7 @@ int main()
     };
 
     //We're intentionally misusing the API here to display the validation layer's effects
-    //if LLRI_DISABLE_VALIDATION is defined, this usage will likely crash internally
+    //if LLRI_DISABLE_VALIDATION is defined, this usage will likely cause an internal crash.
     std::cout << "The next LLRI function call will output a validation error because we passed an incorrect parameter\n";
     const llri::result r = llri::createInstance(instanceDesc, nullptr); //passing nullptr to createInstance()
     std::cout << "Instance create result: " << to_string(r) << "\n";

--- a/applications/samples/001_validation/source.cpp
+++ b/applications/samples/001_validation/source.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file source.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #ifdef NDEBUG

--- a/applications/samples/001_validation/source.cpp
+++ b/applications/samples/001_validation/source.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #ifdef NDEBUG
 //Validation can be an incredibly useful tool, but runtime checks don't come without a performance cost.
 //To prevent validation from causing overhead on builds, you can #define LLRI_DISABLE_VALIDATION.

--- a/applications/sandbox/module/testmodule.hpp
+++ b/applications/sandbox/module/testmodule.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file testmodule.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/applications/sandbox/module/testmodule.hpp
+++ b/applications/sandbox/module/testmodule.hpp
@@ -1,31 +1,22 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <core/core.hpp>
 
 #include "../systems/testsystem.hpp"
 
-/**
- * @file testmodule.hpp
- */
-
-
-/**@class TestModule
- * @brief Custom module.
- */
 class TestModule final : public lgn::Module
 {
 public:
-    /**@brief Will automatically be called once before the start of the application.
-     */
-    virtual void setup()
+    void setup() override
     {
-        // Here you can report any custom components and systems.
-        // (components don't always need ot be reported.)
         reportSystem<TestSystem>();
     }
 
-    /**@brief This function is used to decide the order in which to call the setup function.
-     */
-    virtual lgn::priority_type priority() override
+    lgn::priority_type priority() override
     {
         return default_priority;
     }

--- a/applications/sandbox/sandbox.vcxproj.filters
+++ b/applications/sandbox/sandbox.vcxproj.filters
@@ -9,10 +9,6 @@
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
     </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="source.cpp">

--- a/applications/sandbox/source.cpp
+++ b/applications/sandbox/source.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file source.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #define LEGION_ENTRY

--- a/applications/sandbox/source.cpp
+++ b/applications/sandbox/source.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #define LEGION_ENTRY
 #if defined(NDEBUG)
 #define LEGION_KEEP_CONSOLE

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -49,8 +49,8 @@ void TestSystem::setup()
 
     //Select Instance Extensions
     std::vector<llri::instance_extension> instanceExtensions;
-    if (llri::queryInstanceExtensionSupport(llri::instance_extension_type::APIValidation))
-        instanceExtensions.emplace_back(llri::instance_extension_type::APIValidation, llri::api_validation_ext { true });
+    if (llri::queryInstanceExtensionSupport(llri::instance_extension_type::DriverValidation))
+        instanceExtensions.emplace_back(llri::instance_extension_type::DriverValidation, llri::driver_validation_ext { true });
     if (llri::queryInstanceExtensionSupport(llri::instance_extension_type::GPUValidation))
         instanceExtensions.emplace_back(llri::instance_extension_type::GPUValidation, llri::gpu_validation_ext { true });
 

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -1,4 +1,9 @@
 /**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
+/**
  * Sandbox is a testing area for LLRI development.
  * The code written in sandbox should be up to spec but may not contain the best practices or cleanest examples.
  *

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -7,8 +7,8 @@
 
 #include "testsystem.hpp"
 
-//#define LLRI_DISABLE_VALIDATION //uncommenting this disables internal validation (see docs)
-//#define LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING //uncommenting this disables internal API message polling
+//#define LLRI_DISABLE_VALIDATION //uncommenting this disables API validation (see docs)
+//#define LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING //uncommenting this disables implementation message polling
 #include <llri/llri.hpp>
 
 void callback(const llri::validation_callback_severity& severity, const llri::validation_callback_source& source, const char* message, void* userData)

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file testsystem.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 /**

--- a/applications/sandbox/systems/testsystem.hpp
+++ b/applications/sandbox/systems/testsystem.hpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <core/core.hpp>
 

--- a/applications/sandbox/systems/testsystem.hpp
+++ b/applications/sandbox/systems/testsystem.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file testsystem.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/applications/unit_tests/detail/adapter.cpp
+++ b/applications/unit_tests/detail/adapter.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <doctest/doctest.h>
 

--- a/applications/unit_tests/detail/adapter.cpp
+++ b/applications/unit_tests/detail/adapter.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file adapter.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <doctest/doctest.h>
 

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file device.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/applications/unit_tests/detail/device_extensions.cpp
+++ b/applications/unit_tests/detail/device_extensions.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file device_extensions.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/applications/unit_tests/detail/device_extensions.cpp
+++ b/applications/unit_tests/detail/device_extensions.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <doctest/doctest.h>
 

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <doctest/doctest.h>
 

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file instance.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -35,7 +35,7 @@ TEST_SUITE("Instance")
 
         SUBCASE("[Correct usage] numExtensions > 0 && extensions != nullptr")
         {
-            llri::instance_extension extension{ llri::instance_extension_type::APIValidation, llri::api_validation_ext { false } };
+            llri::instance_extension extension{ llri::instance_extension_type::DriverValidation, llri::driver_validation_ext { false } };
             desc.numExtensions = 1;
             desc.extensions = &extension;
 
@@ -45,7 +45,7 @@ TEST_SUITE("Instance")
         
         SUBCASE("[Incorrect usage] invalid extension type")
         {
-            llri::instance_extension extension{ (llri::instance_extension_type)UINT_MAX, llri::api_validation_ext { false } };
+            llri::instance_extension extension{ (llri::instance_extension_type)UINT_MAX, llri::driver_validation_ext { false } };
 
             desc.numExtensions = 1;
             desc.extensions = &extension;

--- a/applications/unit_tests/detail/instance_extensions.cpp
+++ b/applications/unit_tests/detail/instance_extensions.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file instance_extensions.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/applications/unit_tests/detail/instance_extensions.cpp
+++ b/applications/unit_tests/detail/instance_extensions.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <string>
 #include <doctest/doctest.h>

--- a/applications/unit_tests/detail/instance_extensions.cpp
+++ b/applications/unit_tests/detail/instance_extensions.cpp
@@ -23,18 +23,18 @@ TEST_SUITE("Instance Extensions")
         llri::Instance* instance = nullptr;
         llri::instance_desc desc{ };
 
-        SUBCASE("api_validation_ext")
+        SUBCASE("driver_validation_ext")
         {
-            llri::instance_extension extension{ llri::instance_extension_type::APIValidation, llri::api_validation_ext { true } };
+            llri::instance_extension extension{ llri::instance_extension_type::DriverValidation, llri::driver_validation_ext { true } };
             desc.numExtensions = 1;
             desc.extensions = &extension;
 
             //By checking for support first, we can determine the expected llri::createInstance result
-            const bool supported = llri::queryInstanceExtensionSupport(llri::instance_extension_type::APIValidation);
-            std::string msg = std::string("api_validation_ext is ") + (supported ? std::string("supported") : std::string("not supported"));
+            const bool supported = llri::queryInstanceExtensionSupport(llri::instance_extension_type::DriverValidation);
+            std::string msg = std::string("driver_validation_ext is ") + (supported ? std::string("supported") : std::string("not supported"));
             INFO(msg.data());
 
-            SUBCASE("[Correct usage] enabling api_validation_ext")
+            SUBCASE("[Correct usage] enabling driver_validation_ext")
             {
                 if (supported)
                     CHECK_EQ(llri::createInstance(desc, &instance), llri::result::Success);

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file llri.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/docs/source/fundamentals.rst
+++ b/docs/source/fundamentals.rst
@@ -31,7 +31,7 @@ Extensions
 -----------
 The LLRI API supports various features that may not always be supported by the current environment. These features are available through extensions. LLRI uses extensions extensively to cross the gap between available features for each implementation. Per-extension support is fully **optional**.
 
-Extensions are inserted upon creation of :class:`llri::Instance` and :class:`llri::Device`. Instance extensions usually contain application-wide changes such as validation callbacks, and as such their availability tends to depend on machine configuration and/or implementation featureset. Device extensions are queried through :class:`llri::Adapter` and tend to depend on hardware/feature limits.
+Extensions are inserted upon creation of :class:`llri::Instance` and :class:`llri::Device`. Instance extensions usually contain application-wide changes such as validation callbacks, and as such their availability tends to depend on machine configuration and/or implementation featureset. Adapter extensions are queried through :class:`llri::Adapter` and tend to depend on hardware/feature limits.
 
 Support for extensions is queried prior to Instance/Device creation, for :class:`llri::Instance` extensions this function is :func:`llri::queryInstanceExtensionSupport`, whereas :class:`llri::Adapter` extensions are queried through :func:`llri::Adapter::queryExtensionSupport`.
 
@@ -41,7 +41,7 @@ Validation
 -----------
 LLRI is an explicit API. The user has immense control over resource allocation and state, which results in low API/driver overhead. However, with this much control, it is also much easier to make mistakes. 
 
-To aid in debugging, LLRI does parameter validation by default (disabled by defining LLRI_DISABLE_API_VALIDATION), and also comes with extensions for internal API validation (internal API message polling is disabled by defining LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING). All validation messages (LLRI validation and internal API validation) are forwarded to the validation_callback passed in :struct:`llri::instance_desc`, making it easy for engines to generate informative logs or debug runtime issues.
+To aid in debugging, LLRI does parameter validation by default (disabled by defining LLRI_DISABLE_API_VALIDATION), and also comes with extensions for implementation validation (implementation message polling is disabled by defining LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING). All validation messages (LLRI validation and implementation validation) are forwarded to the validation_callback passed in :struct:`llri::instance_desc`, making it easy for engines to generate informative logs or debug runtime issues.
 
 Threading
 ---------------- 

--- a/legion/engine/llri-dx/detail/adapter.cpp
+++ b/legion/engine/llri-dx/detail/adapter.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file adapter.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-dx/detail/adapter.cpp
+++ b/legion/engine/llri-dx/detail/adapter.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <llri-dx/directx.hpp>
 

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -11,7 +11,7 @@ namespace LLRI_NAMESPACE
 {
     namespace internal
     {
-        result createAPIValidationEXT(const api_validation_ext& ext, void** output);
+        result createDriverValidationEXT(const driver_validation_ext& ext, void** output);
         result createGPUValidationEXT(const gpu_validation_ext& ext, void** output);
 
         result mapHRESULT(const HRESULT& value);
@@ -54,9 +54,9 @@ namespace LLRI_NAMESPACE
 
                 switch (extension.type)
                 {
-                    case instance_extension_type::APIValidation:
+                    case instance_extension_type::DriverValidation:
                     {
-                        extensionCreateResult = internal::createAPIValidationEXT(extension.apiValidation, &output->m_debugAPI);
+                        extensionCreateResult = internal::createDriverValidationEXT(extension.driverValidation, &output->m_debugAPI);
                         if (extensionCreateResult == result::Success)
                             factoryFlags = DXGI_CREATE_FACTORY_DEBUG;
                         break;

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file instance.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -34,7 +34,7 @@ namespace LLRI_NAMESPACE
 
     namespace detail
     {
-        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling)
+        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableImplementationMessagePolling)
         {
             directx::lazyInitializeDirectX();
 
@@ -80,7 +80,7 @@ namespace LLRI_NAMESPACE
             //Store user defined validation callback
             //DirectX creates validation callbacks upon device creation so we just need to store information about this right now.
             output->m_validationCallbackMessenger = nullptr;
-            if (enableInternalAPIMessagePolling && desc.callbackDesc.callback)
+            if (enableImplementationMessagePolling && desc.callbackDesc.callback)
             {
                 output->m_validationCallback = desc.callbackDesc;
                 output->m_shouldConstructValidationCallbackMessenger = true;
@@ -134,7 +134,7 @@ namespace LLRI_NAMESPACE
         {
             if (messenger != nullptr)
             {
-                ID3D12InfoQueue* iq = static_cast<ID3D12InfoQueue*>(messenger);
+                auto* iq = static_cast<ID3D12InfoQueue*>(messenger);
                 const auto numMsg = iq->GetNumStoredMessages();
 
                 for (UINT64 i = 0; i < numMsg; ++i)
@@ -142,9 +142,9 @@ namespace LLRI_NAMESPACE
                     SIZE_T messageLength = 0;
                     iq->GetMessage(i, NULL, &messageLength);
 
-                    D3D12_MESSAGE* pMessage = reinterpret_cast<D3D12_MESSAGE*>(malloc(messageLength));
+                    auto* pMessage = static_cast<D3D12_MESSAGE*>(malloc(messageLength));
                     iq->GetMessage(i, pMessage, &messageLength);
-                    validation(internal::mapSeverity(pMessage->Severity), validation_callback_source::InternalAPI, pMessage->pDescription);
+                    validation(internal::mapSeverity(pMessage->Severity), validation_callback_source::Implementation, pMessage->pDescription);
 
                     free(pMessage);
                 }
@@ -158,7 +158,7 @@ namespace LLRI_NAMESPACE
     {
         adapters->clear();
 
-        //Clear internal pointers, lost adapters will have a nullptr internally
+        //Clear internal pointers, lost adapters will have a nullptr m_ptr
         for (auto& [ptr, adapter] : m_cachedAdapters)
             adapter->m_ptr = nullptr;
 

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <llri-dx/directx.hpp>
 

--- a/legion/engine/llri-dx/detail/instance_extensions.cpp
+++ b/legion/engine/llri-dx/detail/instance_extensions.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file instance_extensions.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-dx/detail/instance_extensions.cpp
+++ b/legion/engine/llri-dx/detail/instance_extensions.cpp
@@ -17,7 +17,7 @@ namespace LLRI_NAMESPACE
 
             switch (type)
             {
-                case instance_extension_type::APIValidation:
+                case instance_extension_type::DriverValidation:
                 {
                     ID3D12Debug* temp = nullptr;
                     return SUCCEEDED(directx::D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
@@ -36,10 +36,10 @@ namespace LLRI_NAMESPACE
     namespace internal
     {
         /**
-         * @brief Enables D3D12 API validation layers where requested.
+         * @brief Enables D3D12 validation layers where requested.
          * @return If the needed debug interface is not found/supported, the function returns result::ErrorExtensionNotSupported.
         */
-        result createAPIValidationEXT(const api_validation_ext& ext, void** output)
+        result createDriverValidationEXT(const driver_validation_ext& ext, void** output)
         {
             if (ext.enable)
             {

--- a/legion/engine/llri-dx/detail/instance_extensions.cpp
+++ b/legion/engine/llri-dx/detail/instance_extensions.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <llri-dx/directx.hpp>
 

--- a/legion/engine/llri-dx/directx.hpp
+++ b/legion/engine/llri-dx/directx.hpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <graphics/directx/d3d12.h>
 #include <dxgi1_6.h>

--- a/legion/engine/llri-dx/directx.hpp
+++ b/legion/engine/llri-dx/directx.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file directx.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri-dx/llri-dx.vcxproj.filters
+++ b/legion/engine/llri-dx/llri-dx.vcxproj.filters
@@ -8,6 +8,9 @@
     <Filter Include="Source Files\detail">
       <UniqueIdentifier>{d4a9415c-3f9a-4b6d-9e29-ee0054f2ee13}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{b3822cb0-b264-4527-93f9-189ffc744eed}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="llri.cpp">
@@ -27,6 +30,8 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="directx.hpp" />
+    <ClInclude Include="directx.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/legion/engine/llri-dx/llri.cpp
+++ b/legion/engine/llri-dx/llri.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 
 namespace LLRI_NAMESPACE

--- a/legion/engine/llri-dx/llri.cpp
+++ b/legion/engine/llri-dx/llri.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file llri.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-dx/utils.cpp
+++ b/legion/engine/llri-dx/utils.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file utils.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-dx/utils.cpp
+++ b/legion/engine/llri-dx/utils.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <llri-dx/directx.hpp>
 

--- a/legion/engine/llri-vk/detail/adapter.cpp
+++ b/legion/engine/llri-vk/detail/adapter.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <llri-vk/utils.hpp>
 #include <graphics/vulkan/volk.h>

--- a/legion/engine/llri-vk/detail/adapter.cpp
+++ b/legion/engine/llri-vk/detail/adapter.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file adapter.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <llri-vk/utils.hpp>
 

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file instance.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -49,7 +49,7 @@ namespace LLRI_NAMESPACE
 
             desc->callback(
                 mapSeverity(severity),
-                validation_callback_source::InternalAPI,
+                validation_callback_source::Implementation,
                 callbackData->pMessage,
                 desc->userData
             );
@@ -62,7 +62,7 @@ namespace LLRI_NAMESPACE
 
     namespace detail
     {
-        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling)
+        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableImplementationMessagePolling)
         {
             internal::lazyInitializeVolk();
 
@@ -115,11 +115,11 @@ namespace LLRI_NAMESPACE
             //Add the debug utils extension for the API callback
             result->m_shouldConstructValidationCallbackMessenger = false;
             result->m_validationCallbackMessenger = nullptr;
-            if (enableInternalAPIMessagePolling && desc.callbackDesc.callback)
+            if (enableImplementationMessagePolling && desc.callbackDesc.callback)
             {
                 const auto& available = internal::queryAvailableExtensions();
                 //Availability of this extension can't be queried externally because API callbacks also include LLRI callbacks
-                //so instead the check is implicit, internal API callbacks aren't guaranteed
+                //so instead the check is implicit, implementation callbacks aren't guaranteed
                 if (available.find(internal::nameHash(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) != available.end())
                 {
                     extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -88,9 +88,9 @@ namespace LLRI_NAMESPACE
                 auto& extension = desc.extensions[i];
                 switch (extension.type)
                 {
-                case instance_extension_type::APIValidation:
+                case instance_extension_type::DriverValidation:
                 {
-                    if (extension.apiValidation.enable)
+                    if (extension.driverValidation.enable)
                         layers.push_back("VK_LAYER_KHRONOS_validation");
                     break;
                 }

--- a/legion/engine/llri-vk/detail/instance_extensions.cpp
+++ b/legion/engine/llri-vk/detail/instance_extensions.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file instance_extensions.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-vk/detail/instance_extensions.cpp
+++ b/legion/engine/llri-vk/detail/instance_extensions.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <llri-vk/utils.hpp>
 

--- a/legion/engine/llri-vk/detail/instance_extensions.cpp
+++ b/legion/engine/llri-vk/detail/instance_extensions.cpp
@@ -19,7 +19,7 @@ namespace LLRI_NAMESPACE
 
             switch (type)
             {
-                case instance_extension_type::APIValidation:
+                case instance_extension_type::DriverValidation:
                 {
                     return layers.find(internal::nameHash("VK_LAYER_KHRONOS_validation")) != layers.end();
                 }

--- a/legion/engine/llri-vk/llri.cpp
+++ b/legion/engine/llri-vk/llri.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 
 #define VOLK_IMPLEMENTATION

--- a/legion/engine/llri-vk/llri.cpp
+++ b/legion/engine/llri-vk/llri.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file llri.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-vk/utils.cpp
+++ b/legion/engine/llri-vk/utils.cpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file utils.cpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #include <llri/llri.hpp>

--- a/legion/engine/llri-vk/utils.cpp
+++ b/legion/engine/llri-vk/utils.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #include <llri/llri.hpp>
 #include <llri-vk/utils.hpp>
 

--- a/legion/engine/llri-vk/utils.hpp
+++ b/legion/engine/llri-vk/utils.hpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <llri/llri.hpp>
 #include <graphics/vulkan/volk.h>

--- a/legion/engine/llri-vk/utils.hpp
+++ b/legion/engine/llri-vk/utils.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file utils.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/adapter.hpp
+++ b/legion/engine/llri/detail/adapter.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file adapter.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/adapter.hpp
+++ b/legion/engine/llri/detail/adapter.hpp
@@ -50,16 +50,15 @@ namespace LLRI_NAMESPACE
 
     /**
      * @brief Basic information about an adapter.
-     * This information is for informative purposes only and the results aren't guaranteed to be the same across APIs.
      */
     struct adapter_info
     {
         /**
-         * @brief The unique ID of the hardware vendor (e.g. NVIDIA, Intel or AMD).
+         * @brief The unique ID of the hardware vendor. This ID is guaranteed to be the same for all adapters from a given vendor.
         */
         uint32_t vendorId;
         /**
-         * @brief The ID of the adapter. This ID refers to the product type/version, meaning that if multiple of the same kind of adapters are present, this ID will be the same among them.
+         * @brief The ID of the adapter. This ID refers to the product type/version, meaning that if multiple of the same kind of adapters were to be present, this ID would be the same among all of them.
         */
         uint32_t adapterId;
         /**
@@ -67,7 +66,7 @@ namespace LLRI_NAMESPACE
         */
         std::string adapterName;
         /**
-         * @brief An informational value describing the type of Adapter. The type does not directly affect how the related adapter operates, but it may correlate with the availability of various features.
+         * @brief An informational value describing the type of Adapter. The type does not directly affect how the related adapter operates, but it **may** correlate with the availability of various features.
         */
         adapter_type adapterType;
     };
@@ -83,7 +82,7 @@ namespace LLRI_NAMESPACE
     };
 
     /**
-     * @brief A compatible adapter (GPU, APU, IGPU, etc.).
+     * @brief Represents a compatible adapter (GPU, APU, IGPU, etc.).
      * This handle is created and owned by the Instance, the user is not responsible for destroying it.
     */
     class Adapter
@@ -94,25 +93,29 @@ namespace LLRI_NAMESPACE
 
     public:
         /**
-         * @brief Get basic information about the Adapter. Do note that this information should be for informative purposes only and the results aren't guaranteed to be the same across APIs.
-         * @return Success upon correct execution of the operation.
+         * @brief Query basic information about the Adapter.
+         * @param info A pointer to the adapter_info structure that needs to be filled.
+         *
          * @return ErrorInvalidUsage if info is nullptr.
          * @return ErrorDeviceLost If the adapter was removed or lost.
         */
         result queryInfo(adapter_info* info) const;
 
         /**
-         * @brief Get a structure with all supported driver/hardware features.
+         * @brief Query a structure with all supported driver/hardware features.
+         * @param features A pointer to the adapter_features structure that needs to be filled.
          *
          * @return Success upon correct execution of the operation.
          * @return ErrorInvalidUsage if features is nullptr.
-         * @return ErrorIncompatibleDriver if the Adapter doesn't support the backend's requested API (either Vulkan 1.0 or DirectX 12 depending on the build).
+         * @return ErrorIncompatibleDriver if the Adapter doesn't support the implementation's requested graphics API.
          * @return ErrorDeviceLost If the adapter was removed or lost.
         */
         result queryFeatures(adapter_features* features) const;
 
         /**
-         * @brief Get the support of a given adapter extension.
+         * @brief Query the support of a given adapter extension.
+         * @param type The type of adapter extension to check against.
+         * @param supported A pointer to the boolean that describes if the extension is supported.
          *
          * @return Success upon correct execution of the operation.
          * @return ErrorInvalidUsage If supported is nullptr.

--- a/legion/engine/llri/detail/adapter.hpp
+++ b/legion/engine/llri/detail/adapter.hpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 //detail includes should be kept to a minimum but
 //are allowed as long as dependencies are upwards (e.g. adapter may include instance but not vice versa)

--- a/legion/engine/llri/detail/adapter.hpp
+++ b/legion/engine/llri/detail/adapter.hpp
@@ -14,13 +14,13 @@ namespace LLRI_NAMESPACE
     enum struct adapter_extension_type;
 
     /**
-     * @brief An informational enum describing the type of Adapter. The type does not directly affect how the related adapter operates, but it may correlate with performance or the availability of various features.
+     * @brief An informational enum describing the type of Adapter. The type does not directly affect how the related adapter operates, but it **may** correlate with performance or the availability of various features.
     */
     enum struct adapter_type
     {
         /**
          * @brief The device type is not recognized as any of the other available types.
-         * This may for example be an APU, or a different form of Vulkan supported processing unit.
+         * This may for example be an APU, or a different form of supported processing unit.
         */
         Other,
         /**
@@ -29,7 +29,7 @@ namespace LLRI_NAMESPACE
         */
         Integrated,
         /**
-         * @brief Separate GPU, usually connected to the host system through PCIE connectors.
+         * @brief Separate GPU, usually connected to the host system through PCIe connectors.
         */
         Discrete,
         /**
@@ -43,7 +43,8 @@ namespace LLRI_NAMESPACE
     };
 
     /**
-     * @brief Converts an adapter_type to a string to aid in debug logging.
+     * @brief Converts an adapter_type to a string.
+     * @return The enum value as a string, or "Invalid adapter_type value" if the value was not recognized as an enum member.
     */
     constexpr const char* to_string(const adapter_type& type);
 

--- a/legion/engine/llri/detail/adapter.inl
+++ b/legion/engine/llri/detail/adapter.inl
@@ -36,7 +36,7 @@ namespace LLRI_NAMESPACE
         }
 #endif
 
-#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_queryInfo(info);
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
@@ -61,7 +61,7 @@ namespace LLRI_NAMESPACE
         }
 #endif
 
-#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_queryFeatures(features);
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
@@ -86,7 +86,7 @@ namespace LLRI_NAMESPACE
         }
 #endif
 
-#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_queryExtensionSupport(type, supported);
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;

--- a/legion/engine/llri/detail/adapter.inl
+++ b/legion/engine/llri/detail/adapter.inl
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file adapter.inl
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/adapter.inl
+++ b/legion/engine/llri/detail/adapter.inl
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <llri/llri.hpp> //Recursive include technically not necessary but helps with intellisense
 

--- a/legion/engine/llri/detail/adapter_extensions.hpp
+++ b/legion/engine/llri/detail/adapter_extensions.hpp
@@ -9,11 +9,9 @@
 namespace LLRI_NAMESPACE
 {
     /**
-     * @brief Describes the kind of adapter extension. <br>
-     * This value is used in adapter_extension and is used in :func:`llri::Instance::createDevice()` to recognize the extension type and
-     * select the correct value from the adapter_extension's union. <br>
-     * <br>
-     * Adapter Extensions aren't guaranteed to be available so use this enum with Adapter::queryExtensionSupport() to find out if your desired extension is available prior to adding the extension to your desc extension array.
+     * @brief Describes the kind of adapter extension. This value is used in adapter_extension and is used in Instance::createDevice() to recognize the extension type and select the correct value from the adapter_extension's union.
+     *
+     * The support of individual adapter extensions is fully **optional** and often depends on hardware limitations, so this enum **should** be used with Adapter::queryExtensionSupport() to find out if an extension is available prior to adding the extension to the device_desc extension array.
     */
     enum struct adapter_extension_type
     {
@@ -24,7 +22,8 @@ namespace LLRI_NAMESPACE
     };
 
     /**
-     * @brief Converts an adapter_extension_type to a string to aid in debug logging.
+     * @brief Converts a adapter_extension_type to a string.
+     * @return The enum value as a string, or "Invalid adapter_extension_type value" if the value was not recognized as an enum member.
     */
     constexpr const char* to_string(const adapter_extension_type& type)
     {
@@ -38,14 +37,28 @@ namespace LLRI_NAMESPACE
     }
 
     /**
-     * @brief Describes an instance extension with its type. <br>
-     * <br>
-     * Adapter Extensions aren't guaranteed to be available so query their availability with Adapter::queryExtensionSupport() to find out if your desired extension is available prior to adding the extension to the desc extension array.
+     * @brief Describes an adapter extension with its type.
+     * 
+     * The support of individual adapter extensions is fully **optional** and often depends on hardware limitations, so their availability **should** be queried with Adapter::queryExtensionSupport() to find out if desired extensions are available prior to adding the extensions to the device_desc extension array.
     */
     struct adapter_extension
     {
+        /**
+         * @brief The type of adapter extension.
+         *
+         * As adapter extensions must be passed in an array, they need some way of storing varying data contiguously. adapter_extensions do so through an unnamed union. When Instance::createDevice() attempts to implement the extension, it uses this enum value to determine which union member to pick from.
+        */
         adapter_extension_type type;
 
+        /**
+         * @brief The adapter extension's information.
+         *
+         * One of the values in this union must be set, and that value must be the same value as the given type.
+         *
+         * Passing a different structure than expected causes undefined behaviour and may result in unexplainable result values or implementation errors.
+         *
+         * All adapter extensions are named after their enum entry, followed with _ext.
+        */
         union
         {
             //Empty until adapter extensions are added

--- a/legion/engine/llri/detail/adapter_extensions.hpp
+++ b/legion/engine/llri/detail/adapter_extensions.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file adapter_extensions.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/adapter_extensions.hpp
+++ b/legion/engine/llri/detail/adapter_extensions.hpp
@@ -4,7 +4,7 @@ namespace LLRI_NAMESPACE
 {
     /**
      * @brief Describes the kind of adapter extension. <br>
-     * This value is used in adapter_extension and is used internally to recognize the extension type and
+     * This value is used in adapter_extension and is used in :func:`llri::Instance::createDevice()` to recognize the extension type and
      * select the correct value from the adapter_extension's union. <br>
      * <br>
      * Adapter Extensions aren't guaranteed to be available so use this enum with Adapter::queryExtensionSupport() to find out if your desired extension is available prior to adding the extension to your desc extension array.

--- a/legion/engine/llri/detail/adapter_extensions.hpp
+++ b/legion/engine/llri/detail/adapter_extensions.hpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 
 namespace LLRI_NAMESPACE

--- a/legion/engine/llri/detail/device.hpp
+++ b/legion/engine/llri/detail/device.hpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 //detail includes should be kept to a minimum but
 //are allowed as long as dependencies are upwards (e.g. device may include adapter but not vice versa)

--- a/legion/engine/llri/detail/device.hpp
+++ b/legion/engine/llri/detail/device.hpp
@@ -22,7 +22,7 @@ namespace LLRI_NAMESPACE
         Adapter* adapter;
         /**
          * @brief The enabled adapter features.
-         * You should only enable features that you'll need because enabling features can disable driver optimizations.
+         * It is **recommended** to only enable features that will be used because unused enabled features might disable driver optimizations.
         */
         adapter_features features;
         /**
@@ -30,14 +30,14 @@ namespace LLRI_NAMESPACE
         */
         uint32_t numExtensions;
         /**
-         * @brief The device extensions, if device_desc::numExtensions > 0, then this has to be a valid pointer to an array of DeviceExtension.
-         * If numExtensions == 0, then this pointer may be nullptr.
+         * @brief The adapter extensions, if device_desc::numExtensions > 0, then this **must** be a valid pointer to an array of adapter_extension.
+         * If device_desc::numExtensions == 0, then this pointer **may** be nullptr.
         */
         adapter_extension* extensions;
     };
 
     /**
-     * @brief A device is a virtual representation of an adapter and can create/destroy resources for the said adapter.
+     * @brief A Device is a virtual representation of an Adapter and can create/destroy/allocate/query resources for the said Adapter.
      */
     class Device
     {

--- a/legion/engine/llri/detail/device.hpp
+++ b/legion/engine/llri/detail/device.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file device.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/device.inl
+++ b/legion/engine/llri/detail/device.inl
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file device.inl
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/device.inl
+++ b/legion/engine/llri/detail/device.inl
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <llri/llri.hpp> //Recursive include technically not necessary but helps with intellisense
 

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -56,18 +56,18 @@ namespace LLRI_NAMESPACE
     {
         /**
          * @brief The message came from the LLRI API directly.
-         * LLRI validation does basic parameter checks to make sure that the API doesn't crash internally.
+         * API validation does basic parameter checks to make sure that the API doesn't crash.
         */
         Validation,
         /**
-         * @brief The message came from the internal API.
-         * Internal API validation needs to be enabled through APIValidationEXT and/or GPUValidationEXT for this kind of message to appear.
+         * @brief The message came from the implementation.
+         * Implementation validation needs to be enabled through APIValidationEXT and/or GPUValidationEXT for this kind of message to appear.
         */
-        InternalAPI,
+        Implementation,
         /**
          * @brief The highest value in this enum.
         */
-        MaxEnum = InternalAPI
+        MaxEnum = Implementation
     };
 
     /**
@@ -76,7 +76,7 @@ namespace LLRI_NAMESPACE
     constexpr const char* to_string(const validation_callback_source& source);
 
     /**
-     * @brief The debug callback function, this function passes a severity (info, warning, error, etc), a source (LLRI validation or Internal API message), the message, and some userdata that can be set in the validation_callback_desc.
+     * @brief The debug callback function, this function passes a severity (info, warning, error, etc), a source (API validation or implementation message), the message, and some user data that can be set in the validation_callback_desc.
     */
     using validation_callback = void(
         const validation_callback_severity& severity,
@@ -89,9 +89,9 @@ namespace LLRI_NAMESPACE
      * @brief The validation callback allows the user to subscribe to validation messages so that they can write the message into their own logging system.
      *
      * The callback contains contextual information about the message, like for example its severity.
-     * The callback may be used for both LLRI validation and internal API validation. The callback will poll messages from the internal API (e.g. Vulkan's debug utils, and DirectX's info queue)
+     * The callback may be used for both API validation and implementation validation. The callback will poll messages from the implementation (e.g. Vulkan's debug utils, and DirectX's info queue)
      *
-     * Internal API messages only occur if api_validation_ext and/or gpu_validation_ext are enabled. If no callback is set, some APIs might still output messages (Vulkan tends to print to the console, whereas DirectX tends to print to the "Output" window in Visual Studio).
+     * Implementation messages only occur if api_validation_ext and/or gpu_validation_ext are enabled. If no callback is set, some APIs might still output messages (Vulkan tends to print to the console, whereas DirectX tends to print to the "Output" window in Visual Studio).
     */
     struct validation_callback_desc
     {
@@ -101,7 +101,7 @@ namespace LLRI_NAMESPACE
         */
         validation_callback* callback;
         /**
-         * @brief Optional user data pointer. Not used internally by the API but it's passed around and sent along the callback.
+         * @brief Optional user data pointer. Not used by LLRI but it's passed around and sent along the callback.
         */
         void* userData;
 
@@ -126,16 +126,16 @@ namespace LLRI_NAMESPACE
         */
         instance_extension* extensions;
         /**
-         * @brief Sets the name of the application in internal API if applicable.
-         * This is not guaranteed but is known to at least apply to Vulkan.
+         * @brief Sets the name of the application in the implementation if applicable.
+         * @note This parameter is not guaranteed to be used but is known to at least apply to Vulkan.
         */
         const char* applicationName;
         /**
          * @brief Describes the optional validation callback. callbackDesc.callback can be nullptr in which case no callbacks will be sent.
          *
-         * Callbacks may or may not be sent depending on the parameters used. If LLRI_DISABLE_VALIDATION is defined, no LLRI validation messages will be sent. If LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING is defined, then no internal API messages will be forwarded.
+         * Callbacks may or may not be sent depending on the parameters used. If LLRI_DISABLE_VALIDATION is defined, no LLRI validation messages will be sent. If LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING is defined, then no implementation messages will be forwarded.
          *
-         * Furthermore, to enable internal API messages, api_validation_ext and/or gpu_validation_ext should be enabled and part of the extensions array.
+         * Furthermore, to enable implementation messages, api_validation_ext and/or gpu_validation_ext should be enabled and part of the extensions array.
         */
         validation_callback_desc callbackDesc;
     };
@@ -145,12 +145,12 @@ namespace LLRI_NAMESPACE
     */
     namespace detail
     {
-        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling);
+        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableImplementationMessagePolling);
         void impl_destroyInstance(Instance* instance);
 
         using messenger_type = void;
         /**
-         * @brief Polls API messages, only called if LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING is not defined.
+         * @brief Polls API messages, only called if LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING is not defined.
          * Used internally only
          * @param validation The validation function / userdata
          * @param messenger This value may differ depending on the function that is calling it, the most relevant messenger will be picked.
@@ -185,7 +185,7 @@ namespace LLRI_NAMESPACE
     */
     class Instance
     {
-        friend result detail::impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableInternalAPIMessagePolling);
+        friend result detail::impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableImplementationMessagePolling);
         friend void detail::impl_destroyInstance(Instance* instance);
 
         friend result llri::createInstance(const instance_desc& desc, Instance** instance);

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -72,7 +72,7 @@ namespace LLRI_NAMESPACE
         Validation,
         /**
          * @brief The message came from the implementation.
-         * Implementation validation needs to be enabled through api_validation_ext and/or gpu_validation_ext for this kind of message to appear.
+         * Implementation validation needs to be enabled through driver_validation_ext and/or gpu_validation_ext for this kind of message to appear.
          *
          * @note This value never occurs if LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING is defined.
         */
@@ -106,7 +106,7 @@ namespace LLRI_NAMESPACE
      * The callback contains contextual information about the message, like for example its severity.
      * The callback may be used for both API validation and implementation validation, each message's source is indicated through the validation_callback_source enum.
      *
-     * @note Implementation messages only occur if api_validation_ext and/or gpu_validation_ext are enabled. If no callback is set, some implementations might still output messages (Vulkan tends to print to stdout, whereas DirectX tends to print to the "Output" window in Visual Studio).
+     * @note Implementation messages only occur if driver_validation_ext and/or gpu_validation_ext are enabled. If no callback is set, some implementations might still output messages (Vulkan tends to print to stdout, whereas DirectX tends to print to the "Output" window in Visual Studio).
     */
     struct validation_callback_desc
     {

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -53,8 +53,7 @@ namespace LLRI_NAMESPACE
 
     /**
      * @brief Converts a validation_callback_severity to a string.
-     * @return The enum value as a string, or "Unknown validation_callback_severity value" if the value was not recognized as an enum member.
-     *
+     * @return The enum value as a string, or "Invalid validation_callback_severity value" if the value was not recognized as an enum member.
     */
     constexpr const char* to_string(const validation_callback_severity& severity);
 
@@ -85,7 +84,7 @@ namespace LLRI_NAMESPACE
 
     /**
      * @brief Converts a validation_callback_source to a string.
-     * @return The enum value as a string, or "Unknown validation_callback_source value" if the value was not recognized as an enum member.
+     * @return The enum value as a string, or "Invalid validation_callback_source value" if the value was not recognized as an enum member.
     */
     constexpr const char* to_string(const validation_callback_source& source);
 

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file instance.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -149,10 +149,6 @@ namespace LLRI_NAMESPACE
         const char* applicationName;
         /**
          * @brief Describes the optional validation callback. callbackDesc.callback can be nullptr in which case no callbacks will be sent.
-         *
-         * Callbacks may or may not be sent depending on the parameters used. If LLRI_DISABLE_VALIDATION is defined, no LLRI validation messages will be sent. If LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING is defined, then no implementation messages will be forwarded.
-         *
-         * Furthermore, to enable implementation messages, api_validation_ext and/or gpu_validation_ext should be enabled and part of the extensions array.
         */
         validation_callback_desc callbackDesc;
     };

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <cstdint>
 #include <vector>

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -138,8 +138,8 @@ namespace LLRI_NAMESPACE
         */
         uint32_t numExtensions;
         /**
-         * @brief The instance extensions, if instance_desc::numExtensions > 0, then this has to be a valid pointer to an array of instance_extension.
-         * If numExtensions == 0, then this pointer may be nullptr.
+         * @brief The instance extensions, if instance_desc::numExtensions > 0, then this **must** be a valid pointer to an array of instance_extension.
+         * If numExtensions == 0, then this pointer **may** be nullptr.
         */
         instance_extension* extensions;
         /**
@@ -148,7 +148,7 @@ namespace LLRI_NAMESPACE
         */
         const char* applicationName;
         /**
-         * @brief Describes the optional validation callback. callbackDesc.callback can be nullptr in which case no callbacks will be sent.
+         * @brief Describes the optional validation callback. callbackDesc.callback **may** be nullptr in which case no callbacks will be sent.
         */
         validation_callback_desc callbackDesc;
     };
@@ -173,28 +173,28 @@ namespace LLRI_NAMESPACE
 
     /**
      * @brief Create an llri Instance.
-     * Like with all API objects, the user is responsible for destroying the instance again using destroyInstance().
+     * Like with all API objects, the user is responsible for destroying the Instance again using destroyInstance().
      * @param desc The description of the instance.
-     * @param instance Must be a valid pointer to an Instance variable.
+     * @param instance Must be a valid pointer to an Instance pointer variable.
      *
      * @return Success upon correct execution of the operation.
      * @return ErrorInvalidUsage if the instance is nullptr, or if desc.numExtensions > 0 and desc.extensions is nullptr.
      * @return ErrorExtensionNotSupported if any of the extensions fail to be created.
-     * @return Otherwise it may also return: ErrorExtensionNotSupported, ErrorOutOfHostMemory, ErrorOutOfDeviceMemory, ErrorInitializationFailed, ErrorIncompatibleDriver.
+     * @return Implementation defined result values: ErrorExtensionNotSupported, ErrorOutOfHostMemory, ErrorOutOfDeviceMemory, ErrorInitializationFailed, ErrorIncompatibleDriver.
     */
     result createInstance(const instance_desc& desc, Instance** instance);
 
     /**
-     * @brief Destroys the given instance and its directly related internal resources (debug info etc).
-     * All resources created through the instance must be destroyed PRIOR to calling this function.
+     * @brief Destroys the given instance and its directly related internal resources.
+     * All resources created through the instance **must** be destroyed prior to calling this function.
      *
-     * @param instance The instance to destroy. This value has to be nullptr or a valid instance pointer.
+     * @param instance The instance to destroy. This value **must** be a valid instance pointer or nullptr.
     */
     void destroyInstance(Instance* instance);
 
     /**
-     * @brief Instance is the center of the application and is used to create most other API objects.
-     * Usually only a single instance of Instance exists within an application, but if so desired, multiple Instance instances are supported.
+     * @brief Instance is the central resource of the application and is used to create most other API objects.
+     * Only a single instance of Instance **may** exist within an application. Creating more instances is not officially supported.
     */
     class Instance
     {
@@ -206,17 +206,19 @@ namespace LLRI_NAMESPACE
 
     public:
         /**
-         * @brief Get a vector of available adapters.
-         * Using this function, you can select one or more adapters for llri::Device creation.
-         * The adapters returned by this function are individual adapters and are listed separately regardless of SLI/Crossfire/Multi-GPU configuration. //TODO: SLI/Crossfire support
+         * @brief Retrieve a vector of adapters available to this application. Adapters usually represent PCIe devices such as GPUs.
+         *
+         * Using this function, you can select one or more adapters for Device creation.
+         * The adapters returned by this function are individual adapters and are listed separately regardless of SLI/Crossfire/Multi-GPU configuration.
+         *
          * @return Success upon correct execution of the operation.
          * @return ErrorInvalidUsage if adapters is nullptr.
-         * @return Otherwise it may return: ErrorOutOfHostMemory, ErrorOutOfDeviceMemory, ErrorInitializationFailed.
+         * @return Implementation defined result values: ErrorOutOfHostMemory, ErrorOutOfDeviceMemory, ErrorInitializationFailed.
         */
         result enumerateAdapters(std::vector<Adapter*>* adapters);
 
         /**
-         * @brief Creates a virtual LLRI device. Device represents one or multiple adapters and enables you to allocate memory, create resources, or send commands to the adapter.
+         * @brief Creates a virtual LLRI device. Device represents one or multiple adapters and is used to allocate memory, create resources, or send commands to the adapter.
          * @return Success upon correct execution of the operation.
          * @return ErrorInvalidUsage if the instance is nullptr, if device is nullptr, if desc.adapter is nullptr, or if desc.numExtensions is more than 0 and desc.extensions is nullptr.
          * @return ErrorDeviceLost if the adapter was lost.
@@ -224,7 +226,9 @@ namespace LLRI_NAMESPACE
         result createDevice(const device_desc& desc, Device** device) const;
 
         /**
-         * @brief Destroy the LLRI device. This does not delete the resources allocated through the device, that responsibility remains with the user.
+         * @brief Destroy the LLRI device.
+         *
+         * All resources created through the device **must** be destroyed prior to calling this function.
         */
         void destroyDevice(Device* device) const;
 

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -174,7 +174,7 @@ namespace LLRI_NAMESPACE
      * @brief Create an llri Instance.
      * Like with all API objects, the user is responsible for destroying the Instance again using destroyInstance().
      * @param desc The description of the instance.
-     * @param instance Must be a valid pointer to an Instance pointer variable.
+     * @param instance Must be a valid pointer to an Instance pointer variable. Upon successful execution of the operation the pointer is set to the resulting instance object.
      *
      * @return Success upon correct execution of the operation.
      * @return ErrorInvalidUsage if the instance is nullptr, or if desc.numExtensions > 0 and desc.extensions is nullptr.
@@ -210,6 +210,8 @@ namespace LLRI_NAMESPACE
          * Using this function, you can select one or more adapters for Device creation.
          * The adapters returned by this function are individual adapters and are listed separately regardless of SLI/Crossfire/Multi-GPU configuration.
          *
+         * @param adapters The vector to fill with available adapters. The vector is cleared at the start of the operation and is only filled if the operation succeeds.
+         *
          * @return Success upon correct execution of the operation.
          * @return ErrorInvalidUsage if adapters is nullptr.
          * @return Implementation defined result values: ErrorOutOfHostMemory, ErrorOutOfDeviceMemory, ErrorInitializationFailed.
@@ -218,6 +220,10 @@ namespace LLRI_NAMESPACE
 
         /**
          * @brief Creates a virtual LLRI device. Device represents one or multiple adapters and is used to allocate memory, create resources, or send commands to the adapter.
+         *
+         * @param desc The description of the device.
+         * @param device A pointer to a device pointer variable. The pointer variable will be set to the resulting device upon successful execution.
+         *
          * @return Success upon correct execution of the operation.
          * @return ErrorInvalidUsage if the instance is nullptr, if device is nullptr, if desc.adapter is nullptr, or if desc.numExtensions is more than 0 and desc.extensions is nullptr.
          * @return ErrorDeviceLost if the adapter was lost.
@@ -228,6 +234,8 @@ namespace LLRI_NAMESPACE
          * @brief Destroy the LLRI device.
          *
          * All resources created through the device **must** be destroyed prior to calling this function.
+         *
+         * @param device The device, **must** be a valid device pointer or nullptr.
         */
         void destroyDevice(Device* device) const;
 

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -138,7 +138,7 @@ namespace LLRI_NAMESPACE
         uint32_t numExtensions;
         /**
          * @brief The instance extensions, if instance_desc::numExtensions > 0, then this **must** be a valid pointer to an array of instance_extension.
-         * If numExtensions == 0, then this pointer **may** be nullptr.
+         * If instance_desc::numExtensions == 0, then this pointer **may** be nullptr.
         */
         instance_extension* extensions;
         /**

--- a/legion/engine/llri/detail/instance.inl
+++ b/legion/engine/llri/detail/instance.inl
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file instance.inl
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/instance.inl
+++ b/legion/engine/llri/detail/instance.inl
@@ -28,8 +28,8 @@ namespace LLRI_NAMESPACE
         {
         case validation_callback_source::Validation:
             return "Validation";
-        case validation_callback_source::InternalAPI:
-            return "InternalAPI";
+        case validation_callback_source::Implementation:
+            return "Implementation";
         }
 
         return "Invalid validation_callback_source value";
@@ -76,7 +76,7 @@ namespace LLRI_NAMESPACE
         }
 #endif
 
-#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = detail::impl_createInstance(desc, instance, true);
         if (*instance)
             detail::impl_pollAPIMessages((*instance)->m_validationCallback, (*instance)->m_validationCallbackMessenger);
@@ -102,7 +102,7 @@ namespace LLRI_NAMESPACE
         }
 #endif
 
-#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_enumerateAdapters(adapters);
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
         return r;
@@ -144,7 +144,7 @@ namespace LLRI_NAMESPACE
         }
 #endif
 
-#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_createDevice(desc, device);
         if (*device)
             detail::impl_pollAPIMessages((*device)->m_validationCallback, (*device)->m_validationCallbackMessenger);
@@ -158,7 +158,7 @@ namespace LLRI_NAMESPACE
     {
         impl_destroyDevice(device);
 
-#ifndef LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         //Can't use device messenger here because the device is destroyed
         detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
 #endif

--- a/legion/engine/llri/detail/instance.inl
+++ b/legion/engine/llri/detail/instance.inl
@@ -45,8 +45,8 @@ namespace LLRI_NAMESPACE
     {
         switch (result)
         {
-        case instance_extension_type::APIValidation:
-            return "APIValidation";
+        case instance_extension_type::DriverValidation:
+            return "DriverValidation";
         case instance_extension_type::GPUValidation:
             return "GPUValidation";
         }

--- a/legion/engine/llri/detail/instance.inl
+++ b/legion/engine/llri/detail/instance.inl
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <llri/llri.hpp> //Recursive include technically not necessary but helps with intellisense
 

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -97,7 +97,9 @@ namespace LLRI_NAMESPACE
     }
 
     /**
-     * @brief Queries the support of the given extension.
+     * @brief Queries the support of the given extension type.
+     * Support for an extension **may** depend on device configuration, hardware compatibility, or other environment factors. The support for extensions **may** differ between implementations.
+     *
      * @return true if the extension is supported, and false if it isn't.
      */
     [[nodiscard]] bool queryInstanceExtensionSupport(const instance_extension_type& type);

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -4,7 +4,7 @@ namespace LLRI_NAMESPACE
 {
     /**
      * @brief Describes the kind of instance extension. <br>
-     * This value is used in instance_extension and is used internally to recognize which value to pick from instance_extension's union. <br>
+     * This value is used in instance_extension and is used in :func:`llri::createInstance()` to recognize which value to pick from instance_extension's union. <br>
      * <br>
      * Instance Extensions aren't guaranteed to be available so use this enum with llri::queryInstanceExtensionSupport() to find out if your desired extension is available prior to adding the extension to your instance desc extension array.
     */
@@ -61,7 +61,7 @@ namespace LLRI_NAMESPACE
         /**
          * @brief The instance extension's information. <br>
          * One of the values in this union must be set, and that value must be the same value as the given type. <br>
-         * Passing a different structure than expected causes undefined behaviour and may result in unexplainable result values or internal API errors. <br>
+         * Passing a different structure than expected causes undefined behaviour and may result in unexplainable result values or implementation errors. <br>
          * All instance extensions are named after their enum entry, followed with EXT or _ext (e.g. instance_extension_type::APIValidation is represented by api_validation_ext).
         */
         union

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -31,7 +31,7 @@ namespace LLRI_NAMESPACE
 
     /**
      * @brief Converts a instance_extension_type to a string.
-     * @return The enum value as a string, or "Unknown instance_extension_type value" if the value was not recognized as an enum member.
+     * @return The enum value as a string, or "Invalid instance_extension_type value" if the value was not recognized as an enum member.
     */
     constexpr const char* to_string(const instance_extension_type& result);
 

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -65,7 +65,7 @@ namespace LLRI_NAMESPACE
         /**
          * @brief The type of instance extension.
          *
-         * As instance extensions must be passed in an array, they need some way of storing varying data contiguously. instance_extensions do so through an unnamed union. When llri::createInstance() attempts to implement the extension, it uses this enum value to determine which union member to pick from.
+         * As instance extensions must be passed in an array, they need some way of storing varying data contiguously. instance_extensions do so through an unnamed union. When createInstance() attempts to implement the extension, it uses this enum value to determine which union member to pick from.
          *
          * @note Accessing incorrect union members is UB, so the union member set **must** match with the instance_extension_type passed.
         */

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -54,16 +54,23 @@ namespace LLRI_NAMESPACE
     };
 
     /**
-     * @brief Describes an instance extension with its type. <br>
-     * instance_extensions aren't guaranteed to be available (hence their name extension), and thus before enabling any instance_extension, you should first query its support with llri::queryInstanceExtensionSupport().
+     * @brief Describes an instance extension with its type.
+     *
+     * Instance extensions are additional features that are injected into the instance. They **may** activate custom behaviour in the instance, or they **may** enable the user to use functions or structures related to the extension.
+     *
+     * The support for each available instance_extension is fully **optional** (hence their name, extension), and thus before enabling any instance_extension, you should first query its support with queryInstanceExtensionSupport().
     */
     struct instance_extension
     {
         /**
-         * @brief The type of instance extension. <br>
-         * This value is used to select the correct union member.
+         * @brief The type of instance extension.
+         *
+         * As instance extensions must be passed in an array, they need some way of storing varying data contiguously. instance_extensions do so through an unnamed union. When llri::createInstance() attempts to implement the extension, it uses this enum value to determine which union member to pick from.
+         *
+         * @note Accessing incorrect union members is UB, so the union member you set **must** match with the instance_extension_type passed.
         */
         instance_extension_type type;
+
         /**
          * @brief The instance extension's information. <br>
          * One of the values in this union must be set, and that value must be the same value as the given type. <br>

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 
 namespace LLRI_NAMESPACE

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -9,19 +9,18 @@
 namespace LLRI_NAMESPACE
 {
     /**
-     * @brief Describes the kind of instance extension. <br>
-     * This value is used in instance_extension and is used in :func:`llri::createInstance()` to recognize which value to pick from instance_extension's union. <br>
-     * <br>
-     * Instance Extensions aren't guaranteed to be available so use this enum with llri::queryInstanceExtensionSupport() to find out if your desired extension is available prior to adding the extension to your instance desc extension array.
+     * @brief Describes the kind of instance extension. This value is used in instance_extension and is used in createInstance() to recognize which value to pick from instance_extension's union.
+     *
+     * The support for each available instance_extension is fully **optional** (hence their name, extension), so it is **recommended** to use this enum with queryInstanceExtensionSupport() to find out if a desired extension is available prior to adding the extension to the instance_desc's extensions array.
     */
     enum struct instance_extension_type
     {
         /**
-         * @brief Validate API calls, their parameters, and context.
+         * @brief Validate operations on a driver level. Driver validation often does additional parameter and context checks for the implementation's operations.
          */
-        APIValidation,
+        DriverValidation,
         /**
-         * @brief Validate shader operations such as buffer reads/writes.
+         * @brief Validate shader operations such as buffer reads/writes. This kind of validation heavily injects itself into shaders, causing a potentially significant performance impact.
         */
         GPUValidation,
         /**
@@ -31,15 +30,16 @@ namespace LLRI_NAMESPACE
     };
 
     /**
-     * @brief Converts an instance_extension_type to a string to aid in debug logging.
+     * @brief Converts a instance_extension_type to a string.
+     * @return The enum value as a string, or "Unknown instance_extension_type value" if the value was not recognized as an enum member.
     */
     constexpr const char* to_string(const instance_extension_type& result);
 
     /**
-     * @brief Enable or disable API-side validation.
-     * API validation checks for parameters and context validity and sends the appropriate messages back if the usage is invalid or otherwise concerning.
+     * @brief Enable or disable driver validation.
+     * Driver validation checks for implementation-side parameters and context validity and sends the appropriate messages back if the usage is invalid or otherwise concerning.
     */
-    struct api_validation_ext
+    struct driver_validation_ext
     {
         bool enable : 1;
     };
@@ -67,24 +67,27 @@ namespace LLRI_NAMESPACE
          *
          * As instance extensions must be passed in an array, they need some way of storing varying data contiguously. instance_extensions do so through an unnamed union. When llri::createInstance() attempts to implement the extension, it uses this enum value to determine which union member to pick from.
          *
-         * @note Accessing incorrect union members is UB, so the union member you set **must** match with the instance_extension_type passed.
+         * @note Accessing incorrect union members is UB, so the union member set **must** match with the instance_extension_type passed.
         */
         instance_extension_type type;
 
         /**
-         * @brief The instance extension's information. <br>
-         * One of the values in this union must be set, and that value must be the same value as the given type. <br>
-         * Passing a different structure than expected causes undefined behaviour and may result in unexplainable result values or implementation errors. <br>
-         * All instance extensions are named after their enum entry, followed with EXT or _ext (e.g. instance_extension_type::APIValidation is represented by api_validation_ext).
+         * @brief The instance extension's information.
+         *
+         * One of the values in this union must be set, and that value must be the same value as the given type.
+         *
+         * Passing a different structure than expected causes undefined behaviour and may result in unexplainable result values or implementation errors.
+         *
+         * All instance extensions are named after their enum entry, followed with _ext (e.g. instance_extension_type::DriverValidation is represented by driver_validation_ext).
         */
         union
         {
-            api_validation_ext apiValidation;
+            driver_validation_ext driverValidation;
             gpu_validation_ext gpuValidation;
         };
 
         instance_extension() = default;
-        instance_extension(const instance_extension_type& type, const api_validation_ext& ext) : type(type), apiValidation(ext) { }
+        instance_extension(const instance_extension_type& type, const driver_validation_ext& ext) : type(type), driverValidation(ext) { }
         instance_extension(const instance_extension_type& type, const gpu_validation_ext& ext) : type(type), gpuValidation(ext) { }
     };
 

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file instance_extensions.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/llri.inl
+++ b/legion/engine/llri/detail/llri.inl
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file llri.inl
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/detail/llri.inl
+++ b/legion/engine/llri/detail/llri.inl
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <llri/llri.hpp> //Recursive include technically not necessary but helps with intellisense
 

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -1,6 +1,7 @@
 /**
- * Copyright 2021-2021 Leon Brands. All rights served.
- * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ * @file llri.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
 
 #pragma once

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -32,7 +32,7 @@
 
 /**
  * @def LLRI_ENABLE_LEGION_NAMESPACING
- * @brief Defining LLRI_ENABLE_LEGION_NAMESPACING changes LLRI's namespace from llri:: to legion::graphics::llri.
+ * @brief Defining LLRI_ENABLE_LEGION_NAMESPACING changes LLRI's namespace from llri to legion::graphics::llri.
  */
 #define LLRI_ENABLE_LEGION_NAMESPACING
 #undef LLRI_ENABLE_LEGION_NAMESPACING //only defined for the doxygen comments
@@ -55,12 +55,16 @@
 namespace LLRI_NAMESPACE
 {
     /**
-     * @enum result
      * @brief Result codes for LLRI operations.
-     * Most LLRI operations return result codes. These result codes provide information about the operation's execution status. Operations that execute properly **can** return result::Success, but they **may** return any of the other non-error result codes. If an operation fails, it **must** return a failing result value, which **may** be result::ErrorUnknown or a more specific appropriate failing result value.
-     *
+     * 
+     * 
+     * Most LLRI operations return result codes. These result codes provide information about the operation's execution status.
+     * Operations that execute properly **can** return result::Success, but they **may** return any of the other non-error result codes.
+     * If an operation fails, it **must** return a failing result value, which **may** be result::ErrorUnknown or a more specific appropriate failing result value.
+     * 
      * @note Codes prefixed with "Error" imply that the operation failed fatally. This **may** mean that further action to recover the application's state is required by the user.
-     * @note Result codes may not provide satisfactory information, so consider using the validation callback to get additional information.
+     *
+     * @note Result codes may not provide enough information, so consider using the validation callback to get additional information.
     */
     enum struct result
     {
@@ -83,7 +87,7 @@ namespace LLRI_NAMESPACE
         ErrorUnknown,
         /**
          * @brief The usage of the operation was invalid.
-         * LLRI validation returns this result code whenever incorrect parameters are passed, but implementations **may** return the code too.
+         * LLRI validation returns this result code whenever its validation fails, but implementations **can** return the code too.
         */
         ErrorInvalidUsage,
         /**
@@ -110,7 +114,7 @@ namespace LLRI_NAMESPACE
         */
         ErrorDeviceRemoved,
         /**
-         * @brief A driver error occurred. After this, the device will be put into the device lost state and will become invalid. See ErrorDeviceLost for more information on device loss.
+         * @brief A driver error occurred. After this, the device will be put into the device lost state and will become invalid. See result::ErrorDeviceLost for more information on device loss.
         */
         ErrorDriverFailure,
         /**
@@ -137,7 +141,7 @@ namespace LLRI_NAMESPACE
 
     /**
      * @brief Converts a result to a string.
-     * @return The enum value as a string, or "Unknown result value" if the result passed was not recognized.
+     * @return The enum value as a string, or "Unknown result value" if the value was not recognized as an enum member.
     */
     constexpr const char* to_string(const result& r);
 }

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -141,7 +141,7 @@ namespace LLRI_NAMESPACE
 
     /**
      * @brief Converts a result to a string.
-     * @return The enum value as a string, or "Unknown result value" if the value was not recognized as an enum member.
+     * @return The enum value as a string, or "Invalid result value" if the value was not recognized as an enum member.
     */
     constexpr const char* to_string(const result& r);
 }

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -38,8 +38,16 @@
 #endif
 
 #if defined(LLRI_ENABLE_LEGION_NAMESPACING)
+/**
+ * @def LLRI_NAMESPACE
+ * @brief The LLRI namespace. This is usually set to "llri", but if LLRI_ENABLE_LEGION_NAMESPACING is defined then the namespace is "legion::graphics::llri".
+ */
 #define LLRI_NAMESPACE legion::graphics::llri
 #else
+/**
+ * @def LLRI_NAMESPACE
+ * @brief The LLRI namespace. This is usually set to "llri", but if LLRI_ENABLE_LEGION_NAMESPACING is defined then the namespace is "legion::graphics::llri".
+ */
 #define LLRI_NAMESPACE llri
 #endif
 

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -8,19 +8,21 @@
 /**
  * @def LLRI_DISABLE_VALIDATION
  * @brief Defining LLRI_DISABLE_VALIDATION disables all LLRI validation.
- * This applies to all validation done by LLRI (not internal API validation), such as nullptr checks on parameters.
- * Disabling LLRI validation may cause API runtime errors if incorrect parameters are passed, but the reduced checks could improve performance.
+ * This applies to all validation done by the LLRI API (not the implementation), such as nullptr checks on parameters.
  *
- * Disabling LLRI validation will also mean that LLRI will not return ErrorInvalidUsage and ErrorDeviceLost where it normally would if incorrect parameters are passed, but the internal API may still return these codes if it fails to operate.
+ * @note Disabling LLRI validation **may** cause API or implementation runtime errors if incorrect parameters are passed, but the reduced checks could improve performance.
+ * @note Disabling LLRI validation means that LLRI **will not** return result::ErrorInvalidUsage and result::ErrorDeviceLost where it normally would if incorrect parameters are passed, but the implementation **may** still return these codes if it fails to operate.
  */
 #define LLRI_DISABLE_VALIDATION
 
  /**
-  * @def LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
-  * @brief Defining LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING disables all internal API message polling.
-  * Internal API message polling can be costly and disabling it can help improve performance, but internal API messages will not be forwarded.
+  * @def LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
+  * @brief Defining LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING disables all implementation message polling.
+  * Implementation message polling can be costly and disabling it could improve performance, but implementation messages aren't forwarded.
+  *
+  * @note Disabling implementation message polling is not guaranteed to prevent implementations from sending messages through other means. Drivers often have their own way of forwarding messages and it's very possible that messages end up in stdout or visual studio's output window.
   */
-#define LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING
+#define LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
 
 /**
  * @def LLRI_ENABLE_LEGION_NAMESPACING
@@ -91,7 +93,7 @@ namespace LLRI_NAMESPACE
         */
         ErrorDeviceRemoved,
         /**
-         * @brief An internal driver error was thrown. After this, the device will be put into the device lost state and will become invalid. See ErrorDeviceLost for more information on device loss.
+         * @brief A driver error occurred. After this, the device will be put into the device lost state and will become invalid. See ErrorDeviceLost for more information on device loss.
         */
         ErrorDriverFailure,
         /**
@@ -103,11 +105,11 @@ namespace LLRI_NAMESPACE
         */
         ErrorOutOfDeviceMemory,
         /**
-         * @brief Initialization of an object failed because of internal or implementation specific reasons.
+         * @brief Initialization of an object failed because of implementation specific reasons.
         */
         ErrorInitializationFailed,
         /**
-         * @brief The requested internal API version (DirectX, Vulkan, etc.) is not supported by the driver.
+         * @brief The implementation (DirectX, Vulkan, etc.) is not supported by the driver.
         */
         ErrorIncompatibleDriver,
         /**

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2021-2021 Leon Brands. All rights served.
+ * License: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
 #pragma once
 #include <cstdint>
 #include <map>


### PR DESCRIPTION
This PR contains a full revision of all in-code docs, including a few minor refactors that make sure that all naming is compliant with the terminology section in the docs.

Most notable refactors:
- LLRI_DISABLE_INTERNAL_API_MESSAGE_POLLING -> LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
- api_validation_ext -> driver_validation_ext
