### PR TITLE
Updated all enums to uint8_t (where applicable)

### DIFF
--- a/applications/samples/001_validation/source.cpp
+++ b/applications/samples/001_validation/source.cpp
@@ -15,7 +15,7 @@
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(const llri::validation_callback_severity& severity, const llri::validation_callback_source& source, const char* message, void* userData)
+void callback(llri::validation_callback_severity severity, llri::validation_callback_source source, const char* message, void* userData)
 {
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -17,7 +17,7 @@
 //#define LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING //uncommenting this disables implementation message polling
 #include <llri/llri.hpp>
 
-void callback(const llri::validation_callback_severity& severity, const llri::validation_callback_source& source, const char* message, void* userData)
+void callback(llri::validation_callback_severity severity, llri::validation_callback_source source, const char* message, void* userData)
 {
     lgn::log::severity sev = lgn::log::severity_info;
     switch (severity)

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -7,7 +7,7 @@
 #include <llri/llri.hpp>
 #include <doctest/doctest.h>
 
-void dummyCallback(const llri::validation_callback_severity& sev, const llri::validation_callback_source& src, const char* message, void* userData)
+void dummyCallback(llri::validation_callback_severity sev, llri::validation_callback_source src, const char* message, void* userData)
 {
     //Empty
 }

--- a/legion/engine/llri-dx/detail/adapter.cpp
+++ b/legion/engine/llri-dx/detail/adapter.cpp
@@ -11,7 +11,7 @@ namespace LLRI_NAMESPACE
 {
     namespace internal
     {
-        result mapHRESULT(const HRESULT& value);
+        result mapHRESULT(HRESULT value);
     }
 
     result Adapter::impl_queryInfo(adapter_info* info) const
@@ -56,7 +56,7 @@ namespace LLRI_NAMESPACE
         return result::Success;
     }
 
-    result Adapter::impl_queryExtensionSupport(const adapter_extension_type& type, bool* supported) const
+    result Adapter::impl_queryExtensionSupport(adapter_extension_type type, bool* supported) const
     {
         *supported = false;
 

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -14,9 +14,9 @@ namespace LLRI_NAMESPACE
         result createDriverValidationEXT(const driver_validation_ext& ext, void** output);
         result createGPUValidationEXT(const gpu_validation_ext& ext, void** output);
 
-        result mapHRESULT(const HRESULT& value);
+        result mapHRESULT(HRESULT value);
 
-        void dummyValidationCallback(const validation_callback_severity&, const validation_callback_source&, const char*, void*) { }
+        void dummyValidationCallback(validation_callback_severity, validation_callback_source, const char*, void*) { }
 
         validation_callback_severity mapSeverity(D3D12_MESSAGE_SEVERITY sev)
         {
@@ -40,7 +40,7 @@ namespace LLRI_NAMESPACE
 
     namespace detail
     {
-        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableImplementationMessagePolling)
+        result impl_createInstance(const instance_desc& desc, Instance** instance, bool enableImplementationMessagePolling)
         {
             directx::lazyInitializeDirectX();
 

--- a/legion/engine/llri-dx/detail/instance_extensions.cpp
+++ b/legion/engine/llri-dx/detail/instance_extensions.cpp
@@ -11,7 +11,7 @@ namespace LLRI_NAMESPACE
 {
     namespace detail
     {
-        bool queryInstanceExtensionSupport(const instance_extension_type& type)
+        bool queryInstanceExtensionSupport(instance_extension_type type)
         {
             directx::lazyInitializeDirectX();
 

--- a/legion/engine/llri-dx/utils.cpp
+++ b/legion/engine/llri-dx/utils.cpp
@@ -14,7 +14,7 @@ namespace LLRI_NAMESPACE
         /**
          * @brief Function that maps an HRESULT to an llri::result.
         */
-        result mapHRESULT(const HRESULT& value)
+        result mapHRESULT(HRESULT value)
         {
             switch (HRESULT_CODE(value))
             {

--- a/legion/engine/llri-vk/detail/adapter.cpp
+++ b/legion/engine/llri-vk/detail/adapter.cpp
@@ -12,7 +12,7 @@ namespace LLRI_NAMESPACE
 {
     namespace internal
     {
-        constexpr adapter_type mapPhysicalDeviceType(const VkPhysicalDeviceType& type)
+        constexpr adapter_type mapPhysicalDeviceType(VkPhysicalDeviceType type)
         {
             switch (type)
             {
@@ -59,7 +59,7 @@ namespace LLRI_NAMESPACE
         return result::Success;
     }
 
-    result Adapter::impl_queryExtensionSupport(const adapter_extension_type& type, bool* supported) const
+    result Adapter::impl_queryExtensionSupport(adapter_extension_type type, bool* supported) const
     {
         *supported = false;
 

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -11,7 +11,7 @@ namespace LLRI_NAMESPACE
 {
     namespace internal
     {
-        constexpr adapter_type mapPhysicalDeviceType(const VkPhysicalDeviceType& type)
+        constexpr adapter_type mapPhysicalDeviceType(VkPhysicalDeviceType type)
         {
             switch (type)
             {
@@ -63,12 +63,12 @@ namespace LLRI_NAMESPACE
             return VK_FALSE;
         }
 
-        void dummyValidationCallback(const validation_callback_severity&, const validation_callback_source&, const char*, void*) { }
+        void dummyValidationCallback(validation_callback_severity, validation_callback_source, const char*, void*) { }
     }
 
     namespace detail
     {
-        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableImplementationMessagePolling)
+        result impl_createInstance(const instance_desc& desc, Instance** instance, bool enableImplementationMessagePolling)
         {
             internal::lazyInitializeVolk();
 

--- a/legion/engine/llri-vk/detail/instance_extensions.cpp
+++ b/legion/engine/llri-vk/detail/instance_extensions.cpp
@@ -11,7 +11,7 @@ namespace LLRI_NAMESPACE
 {
     namespace detail
     {
-        [[nodiscard]] bool queryInstanceExtensionSupport(const instance_extension_type& type)
+        [[nodiscard]] bool queryInstanceExtensionSupport(instance_extension_type type)
         {
             internal::lazyInitializeVolk();
 

--- a/legion/engine/llri-vk/utils.cpp
+++ b/legion/engine/llri-vk/utils.cpp
@@ -66,7 +66,7 @@ namespace LLRI_NAMESPACE
         /**
          * @brief Helper function that converts vk::Result to llri::result
         */
-        result mapVkResult(const VkResult& result)
+        result mapVkResult(VkResult result)
         {
             switch (result)
             {

--- a/legion/engine/llri-vk/utils.hpp
+++ b/legion/engine/llri-vk/utils.hpp
@@ -36,7 +36,7 @@ namespace LLRI_NAMESPACE
         */
         const extension_map& queryAvailableExtensions();
 
-        result mapVkResult(const VkResult& result);
+        result mapVkResult(VkResult result);
 
         unsigned long long nameHash(std::string name);
     }

--- a/legion/engine/llri/detail/adapter.hpp
+++ b/legion/engine/llri/detail/adapter.hpp
@@ -5,18 +5,20 @@
  */
 
 #pragma once
+#include <string>
+
 //detail includes should be kept to a minimum but
 //are allowed as long as dependencies are upwards (e.g. adapter may include instance but not vice versa)
 #include <llri/detail/instance.hpp>
 
 namespace LLRI_NAMESPACE
 {
-    enum struct adapter_extension_type;
+    enum struct adapter_extension_type : uint8_t;
 
     /**
      * @brief An informational enum describing the type of Adapter. The type does not directly affect how the related adapter operates, but it **may** correlate with performance or the availability of various features.
     */
-    enum struct adapter_type
+    enum struct adapter_type : uint8_t
     {
         /**
          * @brief The device type is not recognized as any of the other available types.
@@ -46,7 +48,7 @@ namespace LLRI_NAMESPACE
      * @brief Converts an adapter_type to a string.
      * @return The enum value as a string, or "Invalid adapter_type value" if the value was not recognized as an enum member.
     */
-    constexpr const char* to_string(const adapter_type& type);
+    constexpr const char* to_string(adapter_type type);
 
     /**
      * @brief Basic information about an adapter.
@@ -88,7 +90,7 @@ namespace LLRI_NAMESPACE
     class Adapter
     {
         friend Instance;
-        friend result detail::impl_createInstance(const instance_desc&, Instance**, const bool&);
+        friend result detail::impl_createInstance(const instance_desc&, Instance**, bool);
         friend void detail::impl_destroyInstance(Instance*);
 
     public:
@@ -121,7 +123,7 @@ namespace LLRI_NAMESPACE
          * @return ErrorInvalidUsage If supported is nullptr.
          * @return ErrorDeviceLost If the adapter was removed or lost.
          */
-        result queryExtensionSupport(const adapter_extension_type& type, bool* supported) const;
+        result queryExtensionSupport(adapter_extension_type type, bool* supported) const;
     private:
         //Force private constructor/deconstructor so that only instance can manage lifetime
         Adapter() = default;
@@ -133,6 +135,6 @@ namespace LLRI_NAMESPACE
 
         result impl_queryInfo(adapter_info* info) const;
         result impl_queryFeatures(adapter_features* features) const;
-        result impl_queryExtensionSupport(const adapter_extension_type& type, bool* supported) const;
+        result impl_queryExtensionSupport(adapter_extension_type type, bool* supported) const;
     };
 }

--- a/legion/engine/llri/detail/adapter.inl
+++ b/legion/engine/llri/detail/adapter.inl
@@ -9,7 +9,7 @@
 
 namespace LLRI_NAMESPACE
 {
-    constexpr inline const char* to_string(const adapter_type& type)
+    constexpr inline const char* to_string(adapter_type type)
     {
         switch (type)
         {
@@ -76,7 +76,7 @@ namespace LLRI_NAMESPACE
 #endif
     }
 
-    inline result Adapter::queryExtensionSupport(const adapter_extension_type& type, bool* supported) const
+    inline result Adapter::queryExtensionSupport(adapter_extension_type type, bool* supported) const
     {
 #ifndef LLRI_DISABLE_VALIDATION
         if (supported == nullptr)

--- a/legion/engine/llri/detail/adapter_extensions.hpp
+++ b/legion/engine/llri/detail/adapter_extensions.hpp
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include <cstdint>
 
 namespace LLRI_NAMESPACE
 {
@@ -13,7 +14,7 @@ namespace LLRI_NAMESPACE
      *
      * The support of individual adapter extensions is fully **optional** and often depends on hardware limitations, so this enum **should** be used with Adapter::queryExtensionSupport() to find out if an extension is available prior to adding the extension to the device_desc extension array.
     */
-    enum struct adapter_extension_type
+    enum struct adapter_extension_type : uint8_t
     {
         /**
          * @brief The highest value in this enum.
@@ -25,7 +26,7 @@ namespace LLRI_NAMESPACE
      * @brief Converts a adapter_extension_type to a string.
      * @return The enum value as a string, or "Invalid adapter_extension_type value" if the value was not recognized as an enum member.
     */
-    constexpr const char* to_string(const adapter_extension_type& type)
+    constexpr const char* to_string(adapter_extension_type type)
     {
         switch (type)
         {

--- a/legion/engine/llri/detail/instance.hpp
+++ b/legion/engine/llri/detail/instance.hpp
@@ -11,7 +11,7 @@
 
 namespace LLRI_NAMESPACE
 {
-    enum struct result;
+    enum struct result : uint8_t;
     struct instance_extension;
     class Instance;
     class Adapter;
@@ -23,7 +23,7 @@ namespace LLRI_NAMESPACE
      * @brief Describes the severity of a callback message.
      * @note validation_callback_severity is meant to be used for message filtering, and has no binding impact on the implementation's behaviour.
     */
-    enum struct validation_callback_severity
+    enum struct validation_callback_severity : uint8_t
     {
         /**
          * @brief Extra, often excessive information about API calls, diagnostics, support, etc.
@@ -55,12 +55,12 @@ namespace LLRI_NAMESPACE
      * @brief Converts a validation_callback_severity to a string.
      * @return The enum value as a string, or "Invalid validation_callback_severity value" if the value was not recognized as an enum member.
     */
-    constexpr const char* to_string(const validation_callback_severity& severity);
+    constexpr const char* to_string(validation_callback_severity severity);
 
     /**
      * @brief Describes the source of the validation callback message.
     */
-    enum struct validation_callback_source
+    enum struct validation_callback_source : uint8_t
     {
         /**
          * @brief The message came from the LLRI API.
@@ -86,15 +86,15 @@ namespace LLRI_NAMESPACE
      * @brief Converts a validation_callback_source to a string.
      * @return The enum value as a string, or "Invalid validation_callback_source value" if the value was not recognized as an enum member.
     */
-    constexpr const char* to_string(const validation_callback_source& source);
+    constexpr const char* to_string(validation_callback_source source);
 
     /**
      * @brief The validation callback function.
      * The callback passes numerous parameters which help classify the message's severity and source. It also passes the userData pointer that was initially passed in validation_callback_desc.
     */
     using validation_callback = void(
-        const validation_callback_severity& severity,
-        const validation_callback_source& source,
+        validation_callback_severity severity,
+        validation_callback_source source,
         const char* message,
         void* userData
         );
@@ -123,7 +123,7 @@ namespace LLRI_NAMESPACE
         /**
          * @brief Convenience operator used internally to call the callback.
         */
-        void operator ()(const validation_callback_severity& severity, const validation_callback_source& source, const char* message) const { callback(severity, source, message, userData); }
+        void operator ()(validation_callback_severity severity, validation_callback_source source, const char* message) const { callback(severity, source, message, userData); }
 #endif
     };
 
@@ -157,7 +157,7 @@ namespace LLRI_NAMESPACE
     */
     namespace detail
     {
-        result impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableImplementationMessagePolling);
+        result impl_createInstance(const instance_desc& desc, Instance** instance, bool enableImplementationMessagePolling);
         void impl_destroyInstance(Instance* instance);
 
         using messenger_type = void;
@@ -197,7 +197,7 @@ namespace LLRI_NAMESPACE
     */
     class Instance
     {
-        friend result detail::impl_createInstance(const instance_desc& desc, Instance** instance, const bool& enableImplementationMessagePolling);
+        friend result detail::impl_createInstance(const instance_desc& desc, Instance** instance, bool enableImplementationMessagePolling);
         friend void detail::impl_destroyInstance(Instance* instance);
 
         friend result llri::createInstance(const instance_desc& desc, Instance** instance);

--- a/legion/engine/llri/detail/instance.inl
+++ b/legion/engine/llri/detail/instance.inl
@@ -9,7 +9,7 @@
 
 namespace LLRI_NAMESPACE
 {
-    constexpr inline const char* to_string(const validation_callback_severity& severity)
+    constexpr inline const char* to_string(validation_callback_severity severity)
     {
         switch (severity)
         {
@@ -28,7 +28,7 @@ namespace LLRI_NAMESPACE
         return "Invalid validation_callback_severity value";
     }
 
-    constexpr inline const char* to_string(const validation_callback_source& source)
+    constexpr inline const char* to_string(validation_callback_source source)
     {
         switch (source)
         {
@@ -41,9 +41,9 @@ namespace LLRI_NAMESPACE
         return "Invalid validation_callback_source value";
     }
 
-    constexpr inline const char* to_string(const instance_extension_type& result)
+    constexpr inline const char* to_string(instance_extension_type type)
     {
-        switch (result)
+        switch (type)
         {
         case instance_extension_type::DriverValidation:
             return "DriverValidation";
@@ -54,7 +54,7 @@ namespace LLRI_NAMESPACE
         return "Invalid instance_extension_type value";
     }
 
-    [[nodiscard]] inline bool queryInstanceExtensionSupport(const instance_extension_type& type)
+    [[nodiscard]] inline bool queryInstanceExtensionSupport(instance_extension_type type)
     {
         return detail::queryInstanceExtensionSupport(type);
     }

--- a/legion/engine/llri/detail/instance_extensions.hpp
+++ b/legion/engine/llri/detail/instance_extensions.hpp
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include <cstdint>
 
 namespace LLRI_NAMESPACE
 {
@@ -13,7 +14,7 @@ namespace LLRI_NAMESPACE
      *
      * The support for each available instance_extension is fully **optional** (hence their name, extension), so it is **recommended** to use this enum with queryInstanceExtensionSupport() to find out if a desired extension is available prior to adding the extension to the instance_desc's extensions array.
     */
-    enum struct instance_extension_type
+    enum struct instance_extension_type : uint8_t
     {
         /**
          * @brief Validate operations on a driver level. Driver validation often does additional parameter and context checks for the implementation's operations.
@@ -33,7 +34,7 @@ namespace LLRI_NAMESPACE
      * @brief Converts a instance_extension_type to a string.
      * @return The enum value as a string, or "Invalid instance_extension_type value" if the value was not recognized as an enum member.
     */
-    constexpr const char* to_string(const instance_extension_type& result);
+    constexpr const char* to_string(instance_extension_type type);
 
     /**
      * @brief Enable or disable driver validation.
@@ -87,13 +88,13 @@ namespace LLRI_NAMESPACE
         };
 
         instance_extension() = default;
-        instance_extension(const instance_extension_type& type, const driver_validation_ext& ext) : type(type), driverValidation(ext) { }
-        instance_extension(const instance_extension_type& type, const gpu_validation_ext& ext) : type(type), gpuValidation(ext) { }
+        instance_extension(instance_extension_type type, const driver_validation_ext& ext) : type(type), driverValidation(ext) { }
+        instance_extension(instance_extension_type type, const gpu_validation_ext& ext) : type(type), gpuValidation(ext) { }
     };
 
     namespace detail
     {
-        [[nodiscard]] bool queryInstanceExtensionSupport(const instance_extension_type& type);
+        [[nodiscard]] bool queryInstanceExtensionSupport(instance_extension_type type);
     }
 
     /**
@@ -102,5 +103,5 @@ namespace LLRI_NAMESPACE
      *
      * @return true if the extension is supported, and false if it isn't.
      */
-    [[nodiscard]] bool queryInstanceExtensionSupport(const instance_extension_type& type);
+    [[nodiscard]] bool queryInstanceExtensionSupport(instance_extension_type type);
 }

--- a/legion/engine/llri/detail/llri.inl
+++ b/legion/engine/llri/detail/llri.inl
@@ -9,7 +9,7 @@
 
 namespace LLRI_NAMESPACE
 {
-    constexpr inline const char* to_string(const result& r)
+    constexpr inline const char* to_string(result r)
     {
         switch (r)
         {

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -66,7 +66,7 @@ namespace LLRI_NAMESPACE
      *
      * @note Result codes may not provide enough information, so consider using the validation callback to get additional information.
     */
-    enum struct result
+    enum struct result : uint8_t
     {
         /**
          * @brief The operation executed properly.
@@ -143,7 +143,7 @@ namespace LLRI_NAMESPACE
      * @brief Converts a result to a string.
      * @return The enum value as a string, or "Invalid result value" if the value was not recognized as an enum member.
     */
-    constexpr const char* to_string(const result& r);
+    constexpr const char* to_string(result r);
 }
 
 // ReSharper disable CppUnusedIncludeDirective


### PR DESCRIPTION
All enums are now uint8_t based (where possible) and all excessive const references were removed in favor of plain copies for these small data types